### PR TITLE
feat: MarkdownファイルをPDFに変換する機能を実装

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,4 +31,6 @@ csv = "1.3"
 lopdf = "0.39"
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
+pulldown-cmark = "0.12"
+regex = "1"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod csv_viewer;
 mod image_compressor;
 mod image_editor;
 mod kanban;
+mod markdown_to_pdf;
 mod pdf_tools;
 
 use csv_viewer::{get_csv_info, read_csv, save_csv, CsvData, CsvInfo};
@@ -16,6 +17,10 @@ use image_editor::{
 use kanban::{
     create_task, delete_task, load_board, move_task, update_task, KanbanBoard, Task, TaskColumn,
     TaskPriority,
+};
+use markdown_to_pdf::{
+    convert_markdown_to_pdf, markdown_to_html, read_markdown, MarkdownInfo, MarkdownToHtmlResult,
+    MarkdownToPdfResult,
 };
 use pdf_tools::{
     get_pdf_info, merge_pdfs, split_pdf_by_pages, split_pdf_by_range, PdfInfo, PdfMergeResult,
@@ -88,6 +93,25 @@ fn split_pdf_by_range_cmd(
 #[tauri::command]
 fn merge_pdfs_cmd(input_paths: Vec<String>, output_path: String) -> PdfMergeResult {
     merge_pdfs(&input_paths, &output_path)
+}
+
+#[tauri::command]
+fn read_markdown_cmd(path: String) -> Result<MarkdownInfo, String> {
+    read_markdown(&path)
+}
+
+#[tauri::command]
+fn markdown_to_html_cmd(markdown: String) -> MarkdownToHtmlResult {
+    markdown_to_html(&markdown)
+}
+
+#[tauri::command]
+fn convert_markdown_to_pdf_cmd(
+    markdown: String,
+    output_path: String,
+    source_path: Option<String>,
+) -> MarkdownToPdfResult {
+    convert_markdown_to_pdf(&markdown, &output_path, source_path.as_deref())
 }
 
 #[tauri::command]
@@ -242,7 +266,10 @@ pub fn run() {
             adjust_contrast_cmd,
             apply_filter_cmd,
             flip_horizontal_cmd,
-            flip_vertical_cmd
+            flip_vertical_cmd,
+            read_markdown_cmd,
+            markdown_to_html_cmd,
+            convert_markdown_to_pdf_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/markdown_to_pdf.rs
+++ b/src-tauri/src/markdown_to_pdf.rs
@@ -1,0 +1,440 @@
+use pulldown_cmark::{Options, Parser};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownInfo {
+    pub file_name: String,
+    pub file_size: u64,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownToPdfResult {
+    pub success: bool,
+    pub output_path: String,
+    pub page_count: u32,
+    pub file_size: u64,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownToHtmlResult {
+    pub success: bool,
+    pub html: String,
+    pub error: Option<String>,
+}
+
+pub fn read_markdown(path: &str) -> Result<MarkdownInfo, String> {
+    let metadata =
+        fs::metadata(path).map_err(|e| format!("Failed to read file metadata: {}", e))?;
+    let file_size = metadata.len();
+
+    let file_name = Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+
+    Ok(MarkdownInfo {
+        file_name,
+        file_size,
+        content,
+    })
+}
+
+pub fn markdown_to_html(markdown: &str) -> MarkdownToHtmlResult {
+    let options = Options::all();
+    let parser = Parser::new_ext(markdown, options);
+    let mut html_output = String::new();
+
+    pulldown_cmark::html::push_html(&mut html_output, parser);
+
+    MarkdownToHtmlResult {
+        success: true,
+        html: html_output,
+        error: None,
+    }
+}
+
+fn generate_full_html(markdown: &str, base_path: Option<&str>) -> String {
+    let options = Options::all();
+    let parser = Parser::new_ext(markdown, options);
+    let mut html_body = String::new();
+    pulldown_cmark::html::push_html(&mut html_body, parser);
+
+    // base_pathがあれば画像の相対パスを絶対パスに変換
+    let html_body = if let Some(base) = base_path {
+        convert_relative_paths(&html_body, base)
+    } else {
+        html_body
+    };
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        * {{
+            box-sizing: border-box;
+        }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', sans-serif;
+            font-size: 14px;
+            line-height: 1.8;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            background: #fff;
+        }}
+        h1 {{
+            font-size: 2em;
+            font-weight: 700;
+            margin: 0 0 1em 0;
+            padding-bottom: 0.3em;
+            border-bottom: 2px solid #eee;
+            color: #111;
+        }}
+        h2 {{
+            font-size: 1.5em;
+            font-weight: 600;
+            margin: 1.5em 0 0.5em 0;
+            padding-bottom: 0.2em;
+            border-bottom: 1px solid #eee;
+            color: #222;
+        }}
+        h3 {{
+            font-size: 1.25em;
+            font-weight: 600;
+            margin: 1.2em 0 0.4em 0;
+            color: #333;
+        }}
+        h4, h5, h6 {{
+            font-size: 1.1em;
+            font-weight: 600;
+            margin: 1em 0 0.3em 0;
+            color: #444;
+        }}
+        p {{
+            margin: 0 0 1em 0;
+        }}
+        ul, ol {{
+            margin: 0 0 1em 0;
+            padding-left: 2em;
+        }}
+        li {{
+            margin-bottom: 0.3em;
+        }}
+        code {{
+            font-family: 'SF Mono', 'Monaco', 'Menlo', 'Consolas', monospace;
+            font-size: 0.9em;
+            background: #f5f5f5;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+        }}
+        pre {{
+            background: #f5f5f5;
+            padding: 1em;
+            border-radius: 6px;
+            overflow-x: auto;
+            margin: 0 0 1em 0;
+        }}
+        pre code {{
+            background: none;
+            padding: 0;
+            font-size: 0.85em;
+        }}
+        blockquote {{
+            margin: 0 0 1em 0;
+            padding: 0.5em 1em;
+            border-left: 4px solid #007aff;
+            background: #f8f9fa;
+            color: #555;
+        }}
+        blockquote p {{
+            margin: 0;
+        }}
+        hr {{
+            border: none;
+            border-top: 1px solid #ddd;
+            margin: 2em 0;
+        }}
+        a {{
+            color: #007aff;
+            text-decoration: none;
+        }}
+        a:hover {{
+            text-decoration: underline;
+        }}
+        img {{
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 1em 0;
+            border-radius: 4px;
+        }}
+        table {{
+            width: 100%;
+            border-collapse: collapse;
+            margin: 0 0 1em 0;
+        }}
+        th, td {{
+            border: 1px solid #ddd;
+            padding: 0.5em 0.75em;
+            text-align: left;
+        }}
+        th {{
+            background: #f5f5f5;
+            font-weight: 600;
+        }}
+        tr:nth-child(even) {{
+            background: #fafafa;
+        }}
+        strong {{
+            font-weight: 600;
+        }}
+        em {{
+            font-style: italic;
+        }}
+        @media print {{
+            body {{
+                padding: 0;
+                max-width: none;
+            }}
+            pre {{
+                white-space: pre-wrap;
+                word-wrap: break-word;
+            }}
+        }}
+    </style>
+</head>
+<body>
+{html_body}
+</body>
+</html>"#
+    )
+}
+
+fn convert_relative_paths(html: &str, base_path: &str) -> String {
+    let base_dir = Path::new(base_path)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // img srcの相対パスを絶対パスに変換
+    let re = regex::Regex::new(r#"src="([^"]+)""#).unwrap();
+    re.replace_all(html, |caps: &regex::Captures| {
+        let src = &caps[1];
+        if src.starts_with("http://") || src.starts_with("https://") || src.starts_with("file://") {
+            format!(r#"src="{}""#, src)
+        } else {
+            let abs_path = Path::new(&base_dir).join(src);
+            if abs_path.exists() {
+                format!(r#"src="file://{}""#, abs_path.to_string_lossy())
+            } else {
+                format!(r#"src="{}""#, src)
+            }
+        }
+    })
+    .to_string()
+}
+
+fn find_pdf_converter() -> Option<String> {
+    // wkhtmltopdfをチェック
+    if Command::new("wkhtmltopdf")
+        .arg("--version")
+        .output()
+        .is_ok()
+    {
+        return Some("wkhtmltopdf".to_string());
+    }
+
+    // Chromeをチェック (macOS)
+    let chrome_paths = [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "google-chrome",
+        "chromium",
+    ];
+
+    for path in chrome_paths {
+        if Command::new(path).arg("--version").output().is_ok() {
+            return Some(path.to_string());
+        }
+    }
+
+    None
+}
+
+pub fn convert_markdown_to_pdf(
+    markdown: &str,
+    output_path: &str,
+    source_path: Option<&str>,
+) -> MarkdownToPdfResult {
+    let converter = find_pdf_converter();
+
+    match converter {
+        Some(tool) if tool == "wkhtmltopdf" => {
+            convert_with_wkhtmltopdf(markdown, output_path, source_path)
+        }
+        Some(tool) => convert_with_chrome(&tool, markdown, output_path, source_path),
+        None => MarkdownToPdfResult {
+            success: false,
+            output_path: String::new(),
+            page_count: 0,
+            file_size: 0,
+            error: Some(
+                "PDF converter not found. Please install wkhtmltopdf or Google Chrome.".to_string(),
+            ),
+        },
+    }
+}
+
+fn convert_with_wkhtmltopdf(
+    markdown: &str,
+    output_path: &str,
+    source_path: Option<&str>,
+) -> MarkdownToPdfResult {
+    let html = generate_full_html(markdown, source_path);
+
+    // 一時HTMLファイルを作成
+    let temp_dir = std::env::temp_dir();
+    let temp_html = temp_dir.join(format!("md_to_pdf_{}.html", std::process::id()));
+
+    if let Err(e) = fs::write(&temp_html, &html) {
+        return MarkdownToPdfResult {
+            success: false,
+            output_path: String::new(),
+            page_count: 0,
+            file_size: 0,
+            error: Some(format!("Failed to create temp file: {}", e)),
+        };
+    }
+
+    let result = Command::new("wkhtmltopdf")
+        .args([
+            "--enable-local-file-access",
+            "--encoding",
+            "UTF-8",
+            "--page-size",
+            "A4",
+            "--margin-top",
+            "15mm",
+            "--margin-bottom",
+            "15mm",
+            "--margin-left",
+            "15mm",
+            "--margin-right",
+            "15mm",
+            temp_html.to_str().unwrap(),
+            output_path,
+        ])
+        .output();
+
+    // 一時ファイルを削除
+    let _ = fs::remove_file(&temp_html);
+
+    match result {
+        Ok(output) => {
+            if output.status.success() {
+                let file_size = fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+                MarkdownToPdfResult {
+                    success: true,
+                    output_path: output_path.to_string(),
+                    page_count: 1, // wkhtmltopdfはページ数を返さないため
+                    file_size,
+                    error: None,
+                }
+            } else {
+                MarkdownToPdfResult {
+                    success: false,
+                    output_path: String::new(),
+                    page_count: 0,
+                    file_size: 0,
+                    error: Some(String::from_utf8_lossy(&output.stderr).to_string()),
+                }
+            }
+        }
+        Err(e) => MarkdownToPdfResult {
+            success: false,
+            output_path: String::new(),
+            page_count: 0,
+            file_size: 0,
+            error: Some(format!("Failed to run wkhtmltopdf: {}", e)),
+        },
+    }
+}
+
+fn convert_with_chrome(
+    chrome_path: &str,
+    markdown: &str,
+    output_path: &str,
+    source_path: Option<&str>,
+) -> MarkdownToPdfResult {
+    let html = generate_full_html(markdown, source_path);
+
+    // 一時HTMLファイルを作成
+    let temp_dir = std::env::temp_dir();
+    let temp_html = temp_dir.join(format!("md_to_pdf_{}.html", std::process::id()));
+
+    if let Err(e) = fs::write(&temp_html, &html) {
+        return MarkdownToPdfResult {
+            success: false,
+            output_path: String::new(),
+            page_count: 0,
+            file_size: 0,
+            error: Some(format!("Failed to create temp file: {}", e)),
+        };
+    }
+
+    let result = Command::new(chrome_path)
+        .args([
+            "--headless",
+            "--disable-gpu",
+            "--no-sandbox",
+            "--print-to-pdf-no-header",
+            &format!("--print-to-pdf={}", output_path),
+            &format!("file://{}", temp_html.to_string_lossy()),
+        ])
+        .output();
+
+    // 一時ファイルを削除
+    let _ = fs::remove_file(&temp_html);
+
+    match result {
+        Ok(output) => {
+            if output.status.success() || Path::new(output_path).exists() {
+                let file_size = fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+                MarkdownToPdfResult {
+                    success: true,
+                    output_path: output_path.to_string(),
+                    page_count: 1,
+                    file_size,
+                    error: None,
+                }
+            } else {
+                MarkdownToPdfResult {
+                    success: false,
+                    output_path: String::new(),
+                    page_count: 0,
+                    file_size: 0,
+                    error: Some(String::from_utf8_lossy(&output.stderr).to_string()),
+                }
+            }
+        }
+        Err(e) => MarkdownToPdfResult {
+            success: false,
+            output_path: String::new(),
+            page_count: 0,
+            file_size: 0,
+            error: Some(format!("Failed to run Chrome: {}", e)),
+        },
+    }
+}

--- a/src/components/markdown_to_pdf.rs
+++ b/src/components/markdown_to_pdf.rs
@@ -1,0 +1,413 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "dialog"])]
+    async fn open(options: JsValue) -> JsValue;
+
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "dialog"])]
+    async fn save(options: JsValue) -> JsValue;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MarkdownInfo {
+    pub file_name: String,
+    pub file_size: u64,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownToHtmlResult {
+    pub success: bool,
+    pub html: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownToPdfResult {
+    pub success: bool,
+    pub output_path: String,
+    pub page_count: u32,
+    pub file_size: u64,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct OpenDialogOptions {
+    multiple: bool,
+    directory: bool,
+    filters: Vec<FileFilter>,
+}
+
+#[derive(Serialize)]
+struct SaveDialogOptions {
+    filters: Vec<FileFilter>,
+    #[serde(rename = "defaultPath")]
+    default_path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FileFilter {
+    name: String,
+    extensions: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ReadMarkdownArgs {
+    path: String,
+}
+
+#[derive(Serialize)]
+struct MarkdownToHtmlArgs {
+    markdown: String,
+}
+
+#[derive(Serialize)]
+struct ConvertToPdfArgs {
+    markdown: String,
+    #[serde(rename = "outputPath")]
+    output_path: String,
+    #[serde(rename = "sourcePath")]
+    source_path: Option<String>,
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct MarkdownToPdfProps {
+    #[prop_or_default]
+    pub dropped_file: Option<String>,
+    #[prop_or_default]
+    pub on_file_processed: Callback<()>,
+}
+
+#[function_component(MarkdownToPdf)]
+pub fn markdown_to_pdf(props: &MarkdownToPdfProps) -> Html {
+    let is_processing = use_state(|| false);
+    let input_path = use_state(|| String::new());
+    let markdown_info = use_state(|| Option::<MarkdownInfo>::None);
+    let html_preview = use_state(|| String::new());
+    let convert_result = use_state(|| Option::<MarkdownToPdfResult>::None);
+
+    // Handle dropped file
+    {
+        let dropped_file = props.dropped_file.clone();
+        let on_file_processed = props.on_file_processed.clone();
+        let input_path = input_path.clone();
+        let markdown_info = markdown_info.clone();
+        let html_preview = html_preview.clone();
+        let convert_result = convert_result.clone();
+
+        use_effect_with(dropped_file.clone(), move |dropped_file| {
+            if let Some(path) = dropped_file.clone() {
+                let input_path = input_path.clone();
+                let markdown_info = markdown_info.clone();
+                let html_preview = html_preview.clone();
+                let convert_result = convert_result.clone();
+                let on_file_processed = on_file_processed.clone();
+
+                spawn_local(async move {
+                    let args = serde_wasm_bindgen::to_value(&ReadMarkdownArgs { path: path.clone() })
+                        .unwrap();
+                    let info_result = invoke("read_markdown_cmd", args).await;
+
+                    if let Ok(info) = serde_wasm_bindgen::from_value::<MarkdownInfo>(info_result) {
+                        input_path.set(path);
+                        convert_result.set(None);
+
+                        // Generate HTML preview
+                        let html_args = serde_wasm_bindgen::to_value(&MarkdownToHtmlArgs {
+                            markdown: info.content.clone(),
+                        })
+                        .unwrap();
+                        let html_result = invoke("markdown_to_html_cmd", html_args).await;
+
+                        if let Ok(html_res) =
+                            serde_wasm_bindgen::from_value::<MarkdownToHtmlResult>(html_result)
+                        {
+                            if html_res.success {
+                                html_preview.set(html_res.html);
+                            }
+                        }
+
+                        markdown_info.set(Some(info));
+                    }
+
+                    on_file_processed.emit(());
+                });
+            }
+            || {}
+        });
+    }
+
+    let on_select_file = {
+        let input_path = input_path.clone();
+        let markdown_info = markdown_info.clone();
+        let html_preview = html_preview.clone();
+        let convert_result = convert_result.clone();
+        Callback::from(move |_| {
+            let input_path = input_path.clone();
+            let markdown_info = markdown_info.clone();
+            let html_preview = html_preview.clone();
+            let convert_result = convert_result.clone();
+            spawn_local(async move {
+                let options = OpenDialogOptions {
+                    multiple: false,
+                    directory: false,
+                    filters: vec![FileFilter {
+                        name: "Markdown".to_string(),
+                        extensions: vec!["md".to_string(), "markdown".to_string()],
+                    }],
+                };
+                let options_js = serde_wasm_bindgen::to_value(&options).unwrap();
+                let result = open(options_js).await;
+
+                if let Some(path) = result.as_string() {
+                    input_path.set(path.clone());
+                    convert_result.set(None);
+
+                    let args = serde_wasm_bindgen::to_value(&ReadMarkdownArgs { path }).unwrap();
+                    let info_result = invoke("read_markdown_cmd", args).await;
+
+                    if let Ok(info) = serde_wasm_bindgen::from_value::<MarkdownInfo>(info_result) {
+                        // Generate HTML preview
+                        let html_args = serde_wasm_bindgen::to_value(&MarkdownToHtmlArgs {
+                            markdown: info.content.clone(),
+                        })
+                        .unwrap();
+                        let html_result = invoke("markdown_to_html_cmd", html_args).await;
+
+                        if let Ok(html_res) =
+                            serde_wasm_bindgen::from_value::<MarkdownToHtmlResult>(html_result)
+                        {
+                            if html_res.success {
+                                html_preview.set(html_res.html);
+                            }
+                        }
+
+                        markdown_info.set(Some(info));
+                    }
+                }
+            });
+        })
+    };
+
+    let on_convert = {
+        let input_path = input_path.clone();
+        let markdown_info = markdown_info.clone();
+        let convert_result = convert_result.clone();
+        let is_processing = is_processing.clone();
+
+        Callback::from(move |_| {
+            let markdown_content = match &*markdown_info {
+                Some(info) => info.content.clone(),
+                None => return,
+            };
+
+            let input_path_val = (*input_path).clone();
+            if input_path_val.is_empty() {
+                return;
+            }
+
+            let convert_result = convert_result.clone();
+            let is_processing = is_processing.clone();
+
+            is_processing.set(true);
+
+            let source_path = input_path_val.clone();
+            spawn_local(async move {
+                let default_name = input_path_val
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or("output")
+                    .replace(".md", ".pdf")
+                    .replace(".markdown", ".pdf");
+
+                let save_options = SaveDialogOptions {
+                    filters: vec![FileFilter {
+                        name: "PDF".to_string(),
+                        extensions: vec!["pdf".to_string()],
+                    }],
+                    default_path: Some(default_name),
+                };
+                let save_options_js = serde_wasm_bindgen::to_value(&save_options).unwrap();
+                let save_result = save(save_options_js).await;
+
+                if let Some(output_path) = save_result.as_string() {
+                    let args = ConvertToPdfArgs {
+                        markdown: markdown_content,
+                        output_path,
+                        source_path: Some(source_path),
+                    };
+                    let args_js = serde_wasm_bindgen::to_value(&args).unwrap();
+                    let result = invoke("convert_markdown_to_pdf_cmd", args_js).await;
+
+                    if let Ok(res) = serde_wasm_bindgen::from_value::<MarkdownToPdfResult>(result) {
+                        convert_result.set(Some(res));
+                    }
+                }
+
+                is_processing.set(false);
+            });
+        })
+    };
+
+    let on_reset = {
+        let input_path = input_path.clone();
+        let markdown_info = markdown_info.clone();
+        let html_preview = html_preview.clone();
+        let convert_result = convert_result.clone();
+        Callback::from(move |_| {
+            input_path.set(String::new());
+            markdown_info.set(None);
+            html_preview.set(String::new());
+            convert_result.set(None);
+        })
+    };
+
+    html! {
+        <div class="markdown-to-pdf">
+            // Processing Overlay
+            {if *is_processing {
+                html! {
+                    <div class="processing-overlay">
+                        <div class="processing-content">
+                            <div class="processing-spinner"></div>
+                            <p class="processing-title">{"Converting..."}</p>
+                            <p class="processing-hint">{"Converting Markdown to PDF"}</p>
+                        </div>
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
+
+            // File Selection
+            <div class="section" onclick={on_select_file.clone()}>
+                <div class="drop-zone">
+                    <div class="drop-zone-icon">{"📝"}</div>
+                    <p class="drop-zone-text">{"Click or drag & drop a Markdown file"}</p>
+                    <p class="drop-zone-hint">{"Supports .md and .markdown files"}</p>
+                </div>
+                {if !input_path.is_empty() {
+                    html! { <p class="file-path">{&*input_path}</p> }
+                } else {
+                    html! {}
+                }}
+            </div>
+
+            // Markdown Info
+            {if let Some(info) = &*markdown_info {
+                html! {
+                    <div class="section info-box">
+                        <h3>{"File Info"}</h3>
+                        <div class="info-grid">
+                            <div class="info-item">
+                                <div class="info-item-label">{"File"}</div>
+                                <div class="info-item-value file-name-value">{&info.file_name}</div>
+                            </div>
+                            <div class="info-item">
+                                <div class="info-item-label">{"Size"}</div>
+                                <div class="info-item-value">{format_size(info.file_size)}</div>
+                            </div>
+                            <div class="info-item">
+                                <div class="info-item-label">{"Characters"}</div>
+                                <div class="info-item-value">{info.content.len()}</div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
+
+            // Preview
+            {if !html_preview.is_empty() {
+                html! {
+                    <div class="section">
+                        <h3>{"Preview"}</h3>
+                        <div class="markdown-preview">
+                            <div class="markdown-preview-content">
+                                {Html::from_html_unchecked(AttrValue::from((*html_preview).clone()))}
+                            </div>
+                        </div>
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
+
+            // Action Buttons
+            <div class="pdf-action-buttons">
+                <button
+                    onclick={on_convert}
+                    disabled={input_path.is_empty() || *is_processing}
+                    class="primary-btn compress-btn"
+                >
+                    {"Convert to PDF"}
+                </button>
+                {if !input_path.is_empty() {
+                    html! {
+                        <button
+                            onclick={on_reset.clone()}
+                            class="secondary-btn reset-btn"
+                        >
+                            {"Reset"}
+                        </button>
+                    }
+                } else {
+                    html! {}
+                }}
+            </div>
+
+            // Convert Result
+            {if let Some(result) = &*convert_result {
+                html! {
+                    <div class={if result.success { "section result-box success" } else { "section result-box error" }}>
+                        {if result.success {
+                            html! {
+                                <>
+                                    <h3>{"Conversion Complete!"}</h3>
+                                    <div class="result-stats">
+                                        <div class="result-stat">
+                                            <div class="result-stat-label">{"Pages"}</div>
+                                            <div class="result-stat-value compressed">{result.page_count}</div>
+                                        </div>
+                                        <div class="result-stat">
+                                            <div class="result-stat-label">{"Size"}</div>
+                                            <div class="result-stat-value compressed">{format_size(result.file_size)}</div>
+                                        </div>
+                                    </div>
+                                    <p class="output-path">{format!("{} {}", "📁", result.output_path)}</p>
+                                </>
+                            }
+                        } else {
+                            html! {
+                                <>
+                                    <h3>{"Conversion Failed"}</h3>
+                                    <p>{result.error.clone().unwrap_or_default()}</p>
+                                </>
+                            }
+                        }}
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
+        </div>
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,4 +2,5 @@ pub mod csv_viewer;
 pub mod image_compressor;
 pub mod image_editor;
 pub mod kanban_board;
+pub mod markdown_to_pdf;
 pub mod pdf_tools;

--- a/styles.css
+++ b/styles.css
@@ -1804,6 +1804,159 @@ body {
   cursor: not-allowed;
 }
 
+/* ===== Markdown to PDF ===== */
+.markdown-to-pdf {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.markdown-to-pdf h2 {
+  display: none;
+}
+
+.markdown-preview {
+  background: var(--color-bg-primary);
+  border-radius: var(--radius-sm);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.markdown-preview-content {
+  padding: var(--spacing-md);
+  font-size: var(--text-subhead);
+  line-height: 1.6;
+  color: var(--color-label-primary);
+}
+
+.markdown-preview-content h1 {
+  font-size: var(--text-title1);
+  font-weight: 700;
+  margin: 0 0 var(--spacing-md) 0;
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-separator);
+}
+
+.markdown-preview-content h2 {
+  font-size: var(--text-title2);
+  font-weight: 600;
+  margin: var(--spacing-lg) 0 var(--spacing-sm) 0;
+  padding-bottom: var(--spacing-xs);
+  border-bottom: 1px solid var(--color-separator);
+}
+
+.markdown-preview-content h3 {
+  font-size: var(--text-title3);
+  font-weight: 600;
+  margin: var(--spacing-md) 0 var(--spacing-sm) 0;
+  text-transform: none;
+  letter-spacing: normal;
+  color: var(--color-label-primary);
+}
+
+.markdown-preview-content h4,
+.markdown-preview-content h5,
+.markdown-preview-content h6 {
+  font-size: var(--text-headline);
+  font-weight: 600;
+  margin: var(--spacing-md) 0 var(--spacing-sm) 0;
+}
+
+.markdown-preview-content p {
+  margin: 0 0 var(--spacing-md) 0;
+}
+
+.markdown-preview-content ul,
+.markdown-preview-content ol {
+  margin: 0 0 var(--spacing-md) 0;
+  padding-left: var(--spacing-lg);
+}
+
+.markdown-preview-content li {
+  margin-bottom: var(--spacing-xs);
+}
+
+.markdown-preview-content code {
+  background: var(--color-fill-tertiary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
+  font-size: var(--text-footnote);
+}
+
+.markdown-preview-content pre {
+  background: var(--color-fill-tertiary);
+  padding: var(--spacing-md);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  margin: 0 0 var(--spacing-md) 0;
+}
+
+.markdown-preview-content pre code {
+  background: none;
+  padding: 0;
+}
+
+.markdown-preview-content blockquote {
+  border-left: 4px solid var(--color-tint-blue);
+  margin: 0 0 var(--spacing-md) 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: rgba(0, 122, 255, 0.04);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.markdown-preview-content blockquote p {
+  margin: 0;
+  color: var(--color-label-secondary);
+}
+
+.markdown-preview-content hr {
+  border: none;
+  border-top: 1px solid var(--color-separator);
+  margin: var(--spacing-lg) 0;
+}
+
+.markdown-preview-content a {
+  color: var(--color-tint-blue);
+  text-decoration: none;
+}
+
+.markdown-preview-content a:hover {
+  text-decoration: underline;
+}
+
+.markdown-preview-content strong {
+  font-weight: 600;
+}
+
+.markdown-preview-content em {
+  font-style: italic;
+}
+
+.markdown-preview-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 var(--spacing-md) 0;
+}
+
+.markdown-preview-content th,
+.markdown-preview-content td {
+  border: 1px solid var(--color-separator);
+  padding: var(--spacing-sm);
+  text-align: left;
+}
+
+.markdown-preview-content th {
+  background: var(--color-fill-tertiary);
+  font-weight: 600;
+}
+
+.markdown-preview-content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-sm);
+}
+
 /* ===== Dark Mode ===== */
 @media (prefers-color-scheme: dark) {
   :root {


### PR DESCRIPTION
## Summary
- MarkdownファイルをPDFに変換する機能を追加
- 変換前にHTMLプレビュー表示で確認可能
- Google Chrome（headlessモード）またはwkhtmltopdfを使用した高品質なPDF出力

## Changes
- `src-tauri/src/markdown_to_pdf.rs`: Markdown→HTML変換、PDF出力のバックエンドロジック
- `src/components/markdown_to_pdf.rs`: Markdown to PDF UIコンポーネント
- `src/app.rs`: 新タブ「MD to PDF」を追加、.md/.markdownファイルのドラッグ&ドロップ対応
- `styles.css`: Markdownプレビュー用スタイル

## Features
- Markdownファイルの読み込み（ファイル選択またはドラッグ&ドロップ）
- HTMLプレビュー表示（見出し、リスト、コードブロック、テーブル、引用など対応）
- PDF出力（A4サイズ、日本語フォント対応）
- 画像の相対パス自動解決

## Test Plan
- [ ] Markdownファイルを選択して読み込み確認
- [ ] プレビュー表示の確認（見出し、リスト、コード、画像など）
- [ ] PDFに変換して出力確認
- [ ] 画像を含むMarkdownのPDF変換確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)