### PR TITLE
feat: UUID v4 生成機能を実装

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["HtmlSelectElement", "DataTransfer", "DragEvent", "console", "DomRect", "Document", "Window", "MouseEvent"] }
+web-sys = { version = "0.3", features = ["HtmlSelectElement", "DataTransfer", "DragEvent", "console", "DomRect", "Document", "Window", "MouseEvent", "Navigator", "Clipboard"] }
+gloo-timers = "0.3"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ webp = "0.3"
 csv = "1.3"
 lopdf = "0.39"
 chrono = "0.4"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v7"] }
 pulldown-cmark = "0.12"
 regex = "1"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod image_editor;
 mod kanban;
 mod markdown_to_pdf;
 mod pdf_tools;
+mod uuid_generator;
 
 use csv_viewer::{get_csv_info, read_csv, save_csv, CsvData, CsvInfo};
 use image_compressor::{
@@ -25,6 +26,10 @@ use markdown_to_pdf::{
 use pdf_tools::{
     get_pdf_info, merge_pdfs, split_pdf_by_pages, split_pdf_by_range, PdfInfo, PdfMergeResult,
     PdfSplitResult,
+};
+use uuid_generator::{
+    generate_uuids, validate_uuid, UuidFormat, UuidGenerateOptions, UuidGenerateResult,
+    UuidValidateResult, UuidVersion,
 };
 
 #[tauri::command]
@@ -226,6 +231,21 @@ fn flip_vertical_cmd(input_path: String, output_path: String) -> EditResult {
     flip_vertical(&input_path, &output_path)
 }
 
+#[tauri::command]
+fn generate_uuids_cmd(version: UuidVersion, format: UuidFormat, count: u32) -> UuidGenerateResult {
+    let options = UuidGenerateOptions {
+        version,
+        format,
+        count,
+    };
+    generate_uuids(options)
+}
+
+#[tauri::command]
+fn validate_uuid_cmd(input: String) -> UuidValidateResult {
+    validate_uuid(&input)
+}
+
 use tauri::{Emitter, WindowEvent};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -269,7 +289,9 @@ pub fn run() {
             flip_vertical_cmd,
             read_markdown_cmd,
             markdown_to_html_cmd,
-            convert_markdown_to_pdf_cmd
+            convert_markdown_to_pdf_cmd,
+            generate_uuids_cmd,
+            validate_uuid_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/uuid_generator.rs
+++ b/src-tauri/src/uuid_generator.rs
@@ -1,0 +1,161 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum UuidVersion {
+    V4,
+    V7,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum UuidFormat {
+    Standard,
+    NoHyphens,
+    Uppercase,
+    UppercaseNoHyphens,
+    Braces,
+    Urn,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UuidGenerateOptions {
+    pub version: UuidVersion,
+    pub format: UuidFormat,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UuidGenerateResult {
+    pub success: bool,
+    pub uuids: Vec<String>,
+    pub error: Option<String>,
+}
+
+fn format_uuid(uuid: &Uuid, format: &UuidFormat) -> String {
+    match format {
+        UuidFormat::Standard => uuid.to_string(),
+        UuidFormat::NoHyphens => uuid.simple().to_string(),
+        UuidFormat::Uppercase => uuid.to_string().to_uppercase(),
+        UuidFormat::UppercaseNoHyphens => uuid.simple().to_string().to_uppercase(),
+        UuidFormat::Braces => format!("{{{uuid}}}"),
+        UuidFormat::Urn => uuid.urn().to_string(),
+    }
+}
+
+pub fn generate_uuids(options: UuidGenerateOptions) -> UuidGenerateResult {
+    let count = options.count.clamp(1, 1000);
+
+    let uuids: Vec<String> = (0..count)
+        .map(|_| {
+            let uuid = match options.version {
+                UuidVersion::V4 => Uuid::new_v4(),
+                UuidVersion::V7 => Uuid::now_v7(),
+            };
+            format_uuid(&uuid, &options.format)
+        })
+        .collect();
+
+    UuidGenerateResult {
+        success: true,
+        uuids,
+        error: None,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UuidValidateResult {
+    pub valid: bool,
+    pub version: Option<String>,
+    pub variant: Option<String>,
+    pub error: Option<String>,
+}
+
+pub fn validate_uuid(input: &str) -> UuidValidateResult {
+    match Uuid::parse_str(input.trim()) {
+        Ok(uuid) => {
+            let version = match uuid.get_version_num() {
+                1 => "v1 (Time-based)",
+                2 => "v2 (DCE Security)",
+                3 => "v3 (MD5 Name-based)",
+                4 => "v4 (Random)",
+                5 => "v5 (SHA-1 Name-based)",
+                6 => "v6 (Reordered Time-based)",
+                7 => "v7 (Unix Epoch Time-based)",
+                8 => "v8 (Custom)",
+                _ => "Unknown",
+            };
+
+            let variant = match uuid.get_variant() {
+                uuid::Variant::NCS => "NCS",
+                uuid::Variant::RFC4122 => "RFC 4122",
+                uuid::Variant::Microsoft => "Microsoft",
+                uuid::Variant::Future => "Future",
+                _ => "Unknown",
+            };
+
+            UuidValidateResult {
+                valid: true,
+                version: Some(version.to_string()),
+                variant: Some(variant.to_string()),
+                error: None,
+            }
+        }
+        Err(e) => UuidValidateResult {
+            valid: false,
+            version: None,
+            variant: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_uuid_v4() {
+        let options = UuidGenerateOptions {
+            version: UuidVersion::V4,
+            format: UuidFormat::Standard,
+            count: 5,
+        };
+        let result = generate_uuids(options);
+        assert!(result.success);
+        assert_eq!(result.uuids.len(), 5);
+    }
+
+    #[test]
+    fn test_uuid_formats() {
+        let uuid = Uuid::new_v4();
+
+        let standard = format_uuid(&uuid, &UuidFormat::Standard);
+        assert!(standard.contains('-'));
+
+        let no_hyphens = format_uuid(&uuid, &UuidFormat::NoHyphens);
+        assert!(!no_hyphens.contains('-'));
+        assert_eq!(no_hyphens.len(), 32);
+
+        let uppercase = format_uuid(&uuid, &UuidFormat::Uppercase);
+        assert_eq!(uppercase, uppercase.to_uppercase());
+
+        let braces = format_uuid(&uuid, &UuidFormat::Braces);
+        assert!(braces.starts_with('{') && braces.ends_with('}'));
+
+        let urn = format_uuid(&uuid, &UuidFormat::Urn);
+        assert!(urn.starts_with("urn:uuid:"));
+    }
+
+    #[test]
+    fn test_validate_uuid() {
+        let valid_uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let result = validate_uuid(valid_uuid);
+        assert!(result.valid);
+        assert!(result.version.is_some());
+
+        let invalid_uuid = "not-a-uuid";
+        let result = validate_uuid(invalid_uuid);
+        assert!(!result.valid);
+        assert!(result.error.is_some());
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use crate::components::image_editor::ImageEditor;
 use crate::components::kanban_board::KanbanBoardComponent;
 use crate::components::markdown_to_pdf::MarkdownToPdf;
 use crate::components::pdf_tools::PdfTools;
+use crate::components::uuid_generator::UuidGenerator;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -22,6 +23,7 @@ enum Tab {
     PdfTools,
     MarkdownToPdf,
     KanbanBoard,
+    UuidGenerator,
 }
 
 fn get_file_extension(path: &str) -> Option<String> {
@@ -231,6 +233,16 @@ pub fn app() -> Html {
                     <span class="tab-icon">{"📋"}</span>
                     <span class="tab-label">{"Kanban"}</span>
                 </button>
+                <button
+                    class={if *active_tab == Tab::UuidGenerator { "tab-btn active" } else { "tab-btn" }}
+                    onclick={
+                        let on_click = on_tab_click.clone();
+                        Callback::from(move |_| on_click.emit(Tab::UuidGenerator))
+                    }
+                >
+                    <span class="tab-icon">{"🔑"}</span>
+                    <span class="tab-label">{"UUID"}</span>
+                </button>
             </div>
 
             <div class={if *active_tab == Tab::ImageCompressor { "tab-panel active" } else { "tab-panel" }}>
@@ -265,6 +277,9 @@ pub fn app() -> Html {
             </div>
             <div class={if *active_tab == Tab::KanbanBoard { "tab-panel active" } else { "tab-panel" }}>
                 <KanbanBoardComponent />
+            </div>
+            <div class={if *active_tab == Tab::UuidGenerator { "tab-panel active" } else { "tab-panel" }}>
+                <UuidGenerator />
             </div>
         </main>
     }

--- a/src/components/markdown_to_pdf.rs
+++ b/src/components/markdown_to_pdf.rs
@@ -121,8 +121,9 @@ pub fn markdown_to_pdf(props: &MarkdownToPdfProps) -> Html {
                 let on_file_processed = on_file_processed.clone();
 
                 spawn_local(async move {
-                    let args = serde_wasm_bindgen::to_value(&ReadMarkdownArgs { path: path.clone() })
-                        .unwrap();
+                    let args =
+                        serde_wasm_bindgen::to_value(&ReadMarkdownArgs { path: path.clone() })
+                            .unwrap();
                     let info_result = invoke("read_markdown_cmd", args).await;
 
                     if let Ok(info) = serde_wasm_bindgen::from_value::<MarkdownInfo>(info_result) {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -4,3 +4,4 @@ pub mod image_editor;
 pub mod kanban_board;
 pub mod markdown_to_pdf;
 pub mod pdf_tools;
+pub mod uuid_generator;

--- a/src/components/uuid_generator.rs
+++ b/src/components/uuid_generator.rs
@@ -1,0 +1,449 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::window;
+use yew::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum UuidVersion {
+    V4,
+    V7,
+}
+
+impl UuidVersion {
+    fn label(&self) -> &'static str {
+        match self {
+            UuidVersion::V4 => "v4 (Random)",
+            UuidVersion::V7 => "v7 (Time-based)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum UuidFormat {
+    Standard,
+    NoHyphens,
+    Uppercase,
+    UppercaseNoHyphens,
+    Braces,
+    Urn,
+}
+
+impl UuidFormat {
+    fn label(&self) -> &'static str {
+        match self {
+            UuidFormat::Standard => "標準",
+            UuidFormat::NoHyphens => "ハイフンなし",
+            UuidFormat::Uppercase => "大文字",
+            UuidFormat::UppercaseNoHyphens => "大文字+ハイフンなし",
+            UuidFormat::Braces => "波括弧付き",
+            UuidFormat::Urn => "URN形式",
+        }
+    }
+
+    fn example(&self) -> &'static str {
+        match self {
+            UuidFormat::Standard => "550e8400-e29b-41d4-a716-446655440000",
+            UuidFormat::NoHyphens => "550e8400e29b41d4a716446655440000",
+            UuidFormat::Uppercase => "550E8400-E29B-41D4-A716-446655440000",
+            UuidFormat::UppercaseNoHyphens => "550E8400E29B41D4A716446655440000",
+            UuidFormat::Braces => "{550e8400-e29b-41d4-a716-446655440000}",
+            UuidFormat::Urn => "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GenerateUuidsArgs {
+    version: UuidVersion,
+    format: UuidFormat,
+    count: u32,
+}
+
+#[derive(Serialize)]
+struct ValidateUuidArgs {
+    input: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UuidGenerateResult {
+    success: bool,
+    uuids: Vec<String>,
+    #[allow(dead_code)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UuidValidateResult {
+    valid: bool,
+    version: Option<String>,
+    variant: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Clone, PartialEq)]
+struct GeneratedUuid {
+    value: String,
+    copied: bool,
+}
+
+#[function_component(UuidGenerator)]
+pub fn uuid_generator() -> Html {
+    let selected_version = use_state(|| UuidVersion::V4);
+    let selected_format = use_state(|| UuidFormat::Standard);
+    let count = use_state(|| 1u32);
+    let generated_uuids = use_state(Vec::<GeneratedUuid>::new);
+    let is_generating = use_state(|| false);
+    let validate_input = use_state(String::new);
+    let validate_result = use_state(|| Option::<UuidValidateResult>::None);
+    let copy_all_feedback = use_state(|| false);
+
+    let on_version_change = {
+        let selected_version = selected_version.clone();
+        Callback::from(move |e: Event| {
+            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+            let version = match select.value().as_str() {
+                "V7" => UuidVersion::V7,
+                _ => UuidVersion::V4,
+            };
+            selected_version.set(version);
+        })
+    };
+
+    let on_format_change = {
+        let selected_format = selected_format.clone();
+        Callback::from(move |e: Event| {
+            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+            let format = match select.value().as_str() {
+                "NoHyphens" => UuidFormat::NoHyphens,
+                "Uppercase" => UuidFormat::Uppercase,
+                "UppercaseNoHyphens" => UuidFormat::UppercaseNoHyphens,
+                "Braces" => UuidFormat::Braces,
+                "Urn" => UuidFormat::Urn,
+                _ => UuidFormat::Standard,
+            };
+            selected_format.set(format);
+        })
+    };
+
+    let on_count_change = {
+        let count = count.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            if let Ok(value) = input.value().parse::<u32>() {
+                count.set(value.min(100).max(1));
+            }
+        })
+    };
+
+    let on_generate = {
+        let selected_version = selected_version.clone();
+        let selected_format = selected_format.clone();
+        let count = count.clone();
+        let generated_uuids = generated_uuids.clone();
+        let is_generating = is_generating.clone();
+
+        Callback::from(move |_| {
+            let version = (*selected_version).clone();
+            let format = (*selected_format).clone();
+            let count_value = *count;
+            let generated_uuids = generated_uuids.clone();
+            let is_generating = is_generating.clone();
+
+            is_generating.set(true);
+
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&GenerateUuidsArgs {
+                    version,
+                    format,
+                    count: count_value,
+                })
+                .unwrap();
+
+                let result = invoke("generate_uuids_cmd", args).await;
+
+                if let Ok(res) = serde_wasm_bindgen::from_value::<UuidGenerateResult>(result) {
+                    if res.success {
+                        let new_uuids: Vec<GeneratedUuid> = res
+                            .uuids
+                            .into_iter()
+                            .map(|value| GeneratedUuid {
+                                value,
+                                copied: false,
+                            })
+                            .collect();
+                        generated_uuids.set(new_uuids);
+                    }
+                }
+
+                is_generating.set(false);
+            });
+        })
+    };
+
+    let on_copy_single = {
+        let generated_uuids = generated_uuids.clone();
+        Callback::from(move |index: usize| {
+            let generated_uuids = generated_uuids.clone();
+            if let Some(uuid) = (*generated_uuids).get(index) {
+                let value = uuid.value.clone();
+                if let Some(win) = window() {
+                    let clipboard = win.navigator().clipboard();
+                    let generated_uuids_inner = generated_uuids.clone();
+                    spawn_local(async move {
+                        let _ = wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&value))
+                            .await;
+
+                        let mut uuids = (*generated_uuids_inner).clone();
+                        if let Some(uuid) = uuids.get_mut(index) {
+                            uuid.copied = true;
+                        }
+                        generated_uuids_inner.set(uuids);
+
+                        // Reset copied state after 2 seconds
+                        let generated_uuids_reset = generated_uuids_inner.clone();
+                        gloo_timers::callback::Timeout::new(2000, move || {
+                            let mut uuids = (*generated_uuids_reset).clone();
+                            if let Some(uuid) = uuids.get_mut(index) {
+                                uuid.copied = false;
+                            }
+                            generated_uuids_reset.set(uuids);
+                        })
+                        .forget();
+                    });
+                }
+            }
+        })
+    };
+
+    let on_copy_all = {
+        let generated_uuids = generated_uuids.clone();
+        let copy_all_feedback = copy_all_feedback.clone();
+        Callback::from(move |_| {
+            let uuids = (*generated_uuids).clone();
+            let copy_all_feedback = copy_all_feedback.clone();
+            if !uuids.is_empty() {
+                let all_values: String = uuids
+                    .iter()
+                    .map(|u| u.value.clone())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                if let Some(win) = window() {
+                    let clipboard = win.navigator().clipboard();
+                    spawn_local(async move {
+                        let _ =
+                            wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&all_values))
+                                .await;
+                        copy_all_feedback.set(true);
+
+                        let copy_all_feedback_reset = copy_all_feedback.clone();
+                        gloo_timers::callback::Timeout::new(2000, move || {
+                            copy_all_feedback_reset.set(false);
+                        })
+                        .forget();
+                    });
+                }
+            }
+        })
+    };
+
+    let on_validate_input_change = {
+        let validate_input = validate_input.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            validate_input.set(input.value());
+        })
+    };
+
+    let on_validate = {
+        let validate_input = validate_input.clone();
+        let validate_result = validate_result.clone();
+        Callback::from(move |_| {
+            let input = (*validate_input).clone();
+            let validate_result = validate_result.clone();
+
+            if input.trim().is_empty() {
+                validate_result.set(None);
+                return;
+            }
+
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&ValidateUuidArgs { input }).unwrap();
+                let result = invoke("validate_uuid_cmd", args).await;
+
+                if let Ok(res) = serde_wasm_bindgen::from_value::<UuidValidateResult>(result) {
+                    validate_result.set(Some(res));
+                }
+            });
+        })
+    };
+
+    html! {
+        <div class="uuid-generator">
+            // Generate Section
+            <div class="section uuid-generate-section">
+                <h3>{"UUID 生成"}</h3>
+
+                <div class="uuid-options">
+                    <div class="form-group">
+                        <label>{"バージョン"}</label>
+                        <select class="form-select" onchange={on_version_change}>
+                            <option value="V4" selected={*selected_version == UuidVersion::V4}>
+                                {UuidVersion::V4.label()}
+                            </option>
+                            <option value="V7" selected={*selected_version == UuidVersion::V7}>
+                                {UuidVersion::V7.label()}
+                            </option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label>{"形式"}</label>
+                        <select class="form-select" onchange={on_format_change}>
+                            <option value="Standard" selected={*selected_format == UuidFormat::Standard}>
+                                {UuidFormat::Standard.label()}
+                            </option>
+                            <option value="NoHyphens" selected={*selected_format == UuidFormat::NoHyphens}>
+                                {UuidFormat::NoHyphens.label()}
+                            </option>
+                            <option value="Uppercase" selected={*selected_format == UuidFormat::Uppercase}>
+                                {UuidFormat::Uppercase.label()}
+                            </option>
+                            <option value="UppercaseNoHyphens" selected={*selected_format == UuidFormat::UppercaseNoHyphens}>
+                                {UuidFormat::UppercaseNoHyphens.label()}
+                            </option>
+                            <option value="Braces" selected={*selected_format == UuidFormat::Braces}>
+                                {UuidFormat::Braces.label()}
+                            </option>
+                            <option value="Urn" selected={*selected_format == UuidFormat::Urn}>
+                                {UuidFormat::Urn.label()}
+                            </option>
+                        </select>
+                        <div class="format-example">
+                            {"例: "}{selected_format.example()}
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label>{"生成個数"}</label>
+                        <input
+                            type="number"
+                            class="form-input"
+                            min="1"
+                            max="100"
+                            value={count.to_string()}
+                            oninput={on_count_change}
+                        />
+                    </div>
+                </div>
+
+                <button
+                    class="primary-btn generate-btn"
+                    onclick={on_generate}
+                    disabled={*is_generating}
+                >
+                    if *is_generating {
+                        <span class="processing">
+                            <span class="spinner"></span>
+                            {"生成中..."}
+                        </span>
+                    } else {
+                        {"UUID を生成"}
+                    }
+                </button>
+            </div>
+
+            // Generated UUIDs Section
+            if !generated_uuids.is_empty() {
+                <div class="section uuid-results-section">
+                    <div class="uuid-results-header">
+                        <h3>{format!("生成結果 ({} 件)", generated_uuids.len())}</h3>
+                        <button
+                            class={classes!("secondary-btn", "copy-all-btn", (*copy_all_feedback).then_some("copied"))}
+                            onclick={on_copy_all}
+                        >
+                            if *copy_all_feedback {
+                                {"✓ コピー完了"}
+                            } else {
+                                {"すべてコピー"}
+                            }
+                        </button>
+                    </div>
+                    <div class="uuid-list">
+                        { for (*generated_uuids).iter().enumerate().map(|(index, uuid)| {
+                            let on_copy = {
+                                let on_copy_single = on_copy_single.clone();
+                                Callback::from(move |_| on_copy_single.emit(index))
+                            };
+                            html! {
+                                <div class="uuid-item">
+                                    <code class="uuid-value">{&uuid.value}</code>
+                                    <button
+                                        class={classes!("copy-btn", uuid.copied.then_some("copied"))}
+                                        onclick={on_copy}
+                                    >
+                                        if uuid.copied {
+                                            {"✓"}
+                                        } else {
+                                            {"📋"}
+                                        }
+                                    </button>
+                                </div>
+                            }
+                        })}
+                    </div>
+                </div>
+            }
+
+            // Validate Section
+            <div class="section uuid-validate-section">
+                <h3>{"UUID 検証"}</h3>
+                <div class="validate-input-row">
+                    <input
+                        type="text"
+                        class="form-input"
+                        placeholder="検証するUUIDを入力..."
+                        value={(*validate_input).clone()}
+                        oninput={on_validate_input_change}
+                    />
+                    <button class="secondary-btn" onclick={on_validate}>
+                        {"検証"}
+                    </button>
+                </div>
+
+                if let Some(result) = &*validate_result {
+                    <div class={classes!("validate-result", result.valid.then_some("valid").or(Some("invalid")))}>
+                        if result.valid {
+                            <div class="validate-status">{"✓ 有効なUUID"}</div>
+                            if let Some(version) = &result.version {
+                                <div class="validate-info">
+                                    <span class="info-label">{"バージョン:"}</span>
+                                    <span class="info-value">{version}</span>
+                                </div>
+                            }
+                            if let Some(variant) = &result.variant {
+                                <div class="validate-info">
+                                    <span class="info-label">{"バリアント:"}</span>
+                                    <span class="info-value">{variant}</span>
+                                </div>
+                            }
+                        } else {
+                            <div class="validate-status">{"✕ 無効なUUID"}</div>
+                            if let Some(error) = &result.error {
+                                <div class="validate-error">{error}</div>
+                            }
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -2078,6 +2078,185 @@ body {
   border-radius: var(--radius-md);
 }
 
+/* ===== UUID Generator ===== */
+.uuid-generator {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.uuid-generator h2 {
+  display: none;
+}
+
+.uuid-options {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .uuid-options {
+    grid-template-columns: 1fr;
+  }
+}
+
+.format-example {
+  margin-top: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  word-break: break-all;
+}
+
+.generate-btn {
+  width: 100%;
+}
+
+.uuid-results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.uuid-results-header h3 {
+  margin: 0;
+}
+
+.copy-all-btn {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+}
+
+.copy-all-btn.copied {
+  background: var(--success-dim);
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.uuid-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.uuid-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.uuid-item:hover {
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
+}
+
+.uuid-value {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--accent-primary);
+  word-break: break-all;
+  user-select: all;
+}
+
+.copy-btn {
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--bg-overlay);
+  color: var(--text-secondary);
+  font-size: 16px;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.copy-btn:hover {
+  background: var(--accent-primary);
+  color: var(--bg-base);
+}
+
+.copy-btn.copied {
+  background: var(--success);
+  color: white;
+}
+
+.validate-input-row {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.validate-input-row .form-input {
+  flex: 1;
+}
+
+.validate-result {
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  animation: slideUp var(--duration-normal) var(--ease-out);
+}
+
+.validate-result.valid {
+  background: var(--success-dim);
+  border: 1px solid rgba(0, 230, 118, 0.3);
+}
+
+.validate-result.invalid {
+  background: var(--error-dim);
+  border: 1px solid rgba(255, 82, 82, 0.3);
+}
+
+.validate-status {
+  font-size: var(--text-base);
+  font-weight: 600;
+  margin-bottom: var(--space-3);
+}
+
+.validate-result.valid .validate-status {
+  color: var(--success);
+}
+
+.validate-result.invalid .validate-status {
+  color: var(--error);
+}
+
+.validate-info {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.info-label {
+  color: var(--text-tertiary);
+}
+
+.info-value {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.validate-error {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
 /* ===== Utility Classes ===== */
 .container > h1 {
   font-family: var(--font-display);


### PR DESCRIPTION
## Summary
- UUID v4 (ランダム) と v7 (タイムベース) の生成機能を追加
- 6つの形式オプション（標準/ハイフンなし/大文字/大文字+ハイフンなし/波括弧付き/URN形式）をサポート
- 生成個数の指定機能（1〜100件）を実装
- ワンクリックコピー機能（個別UUID/全UUID一括）を追加
- UUID検証機能（バージョン・バリアント情報表示）を実装

## 動作確認
- [x] UUID v4/v7 の生成が正常に動作することを確認
- [x] 各形式オプションで正しいフォーマットが出力されることを確認
- [x] 生成個数指定が1〜100件の範囲で動作することを確認
- [x] コピー機能が正常に動作することを確認
- [x] UUID検証機能が有効/無効なUUIDを正しく判定することを確認
- [x] ユニットテストがすべてパスすることを確認

## 確認事項
- [x] コードがフォーマットされている (`cargo fmt`)
- [x] lintエラーがない (`cargo clippy`)
- [x] テストがパスしている (`cargo test`)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)