### PR TITLE
feat: パスワード生成機能を実装 (#30)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,4 +33,5 @@ chrono = "0.4"
 uuid = { version = "1", features = ["v4", "v7"] }
 pulldown-cmark = "0.12"
 regex = "1"
+rand = "0.8"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod image_compressor;
 mod image_editor;
 mod kanban;
 mod markdown_to_pdf;
+mod password_generator;
 mod pdf_tools;
 mod uuid_generator;
 
@@ -22,6 +23,10 @@ use kanban::{
 use markdown_to_pdf::{
     convert_markdown_to_pdf, markdown_to_html, read_markdown, MarkdownInfo, MarkdownToHtmlResult,
     MarkdownToPdfResult,
+};
+use password_generator::{
+    generate_passphrases, generate_passwords, PassphraseOptions, PasswordGenerateResult,
+    PasswordOptions,
 };
 use pdf_tools::{
     get_pdf_info, merge_pdfs, split_pdf_by_pages, split_pdf_by_range, PdfInfo, PdfMergeResult,
@@ -246,6 +251,16 @@ fn validate_uuid_cmd(input: String) -> UuidValidateResult {
     validate_uuid(&input)
 }
 
+#[tauri::command]
+fn generate_passwords_cmd(options: PasswordOptions) -> PasswordGenerateResult {
+    generate_passwords(options)
+}
+
+#[tauri::command]
+fn generate_passphrases_cmd(options: PassphraseOptions) -> PasswordGenerateResult {
+    generate_passphrases(options)
+}
+
 use tauri::{Emitter, WindowEvent};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -291,7 +306,9 @@ pub fn run() {
             markdown_to_html_cmd,
             convert_markdown_to_pdf_cmd,
             generate_uuids_cmd,
-            validate_uuid_cmd
+            validate_uuid_cmd,
+            generate_passwords_cmd,
+            generate_passphrases_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/password_generator.rs
+++ b/src-tauri/src/password_generator.rs
@@ -1,0 +1,373 @@
+use rand::seq::SliceRandom;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+const LOWERCASE: &str = "abcdefghijklmnopqrstuvwxyz";
+const UPPERCASE: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const DIGITS: &str = "0123456789";
+const SYMBOLS: &str = "!@#$%^&*()_+-=[]{}|;:,.<>?";
+const AMBIGUOUS_CHARS: &str = "0O1lI";
+
+const WORD_LIST: &[&str] = &[
+    "apple", "banana", "cherry", "dragon", "eagle", "falcon", "guitar", "hammer", "island",
+    "jungle", "kingdom", "lemon", "marble", "nectar", "orange", "puzzle", "quartz", "river",
+    "sunset", "thunder", "umbrella", "violin", "winter", "xenon", "yellow", "zephyr", "anchor",
+    "beacon", "castle", "diamond", "ember", "forest", "glacier", "harbor", "ivory", "jasper",
+    "knight", "lantern", "meadow", "noble", "ocean", "phoenix", "quantum", "rapids", "silver",
+    "temple", "unity", "valley", "wonder", "crystal", "breeze", "cosmos", "dusk", "flame", "grove",
+    "horizon", "jade", "karma", "lotus", "mist", "nova", "orbit", "prism", "quest", "reef",
+    "storm", "tide", "vine", "wave", "zen", "aurora", "blaze", "cliff", "delta", "echo", "frost",
+    "glow", "haven", "ink", "jewel", "kite", "lunar", "maple", "north", "opal", "pearl", "raven",
+    "spark", "terra", "ultra", "vivid", "wisp",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordOptions {
+    pub length: u32,
+    pub include_lowercase: bool,
+    pub include_uppercase: bool,
+    pub include_digits: bool,
+    pub include_symbols: bool,
+    pub exclude_ambiguous: bool,
+    pub custom_exclude: String,
+    pub count: u32,
+}
+
+impl Default for PasswordOptions {
+    fn default() -> Self {
+        Self {
+            length: 16,
+            include_lowercase: true,
+            include_uppercase: true,
+            include_digits: true,
+            include_symbols: true,
+            exclude_ambiguous: false,
+            custom_exclude: String::new(),
+            count: 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PassphraseOptions {
+    pub word_count: u32,
+    pub separator: String,
+    pub capitalize: bool,
+    pub include_number: bool,
+    pub count: u32,
+}
+
+impl Default for PassphraseOptions {
+    fn default() -> Self {
+        Self {
+            word_count: 4,
+            separator: "-".to_string(),
+            capitalize: true,
+            include_number: true,
+            count: 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneratedPassword {
+    pub value: String,
+    pub strength: PasswordStrength,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PasswordStrength {
+    pub score: u32,
+    pub label: String,
+    pub entropy: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PasswordGenerateResult {
+    pub success: bool,
+    pub passwords: Vec<GeneratedPassword>,
+    pub error: Option<String>,
+}
+
+fn build_charset(options: &PasswordOptions) -> String {
+    let mut charset = String::new();
+
+    if options.include_lowercase {
+        charset.push_str(LOWERCASE);
+    }
+    if options.include_uppercase {
+        charset.push_str(UPPERCASE);
+    }
+    if options.include_digits {
+        charset.push_str(DIGITS);
+    }
+    if options.include_symbols {
+        charset.push_str(SYMBOLS);
+    }
+
+    if options.exclude_ambiguous {
+        charset = charset
+            .chars()
+            .filter(|c| !AMBIGUOUS_CHARS.contains(*c))
+            .collect();
+    }
+
+    if !options.custom_exclude.is_empty() {
+        charset = charset
+            .chars()
+            .filter(|c| !options.custom_exclude.contains(*c))
+            .collect();
+    }
+
+    charset
+}
+
+fn calculate_strength(password: &str, charset_size: usize) -> PasswordStrength {
+    let length = password.len();
+    let entropy = (length as f64) * (charset_size as f64).log2();
+
+    let (score, label) = if entropy < 28.0 {
+        (1, "非常に弱い")
+    } else if entropy < 36.0 {
+        (2, "弱い")
+    } else if entropy < 60.0 {
+        (3, "普通")
+    } else if entropy < 80.0 {
+        (4, "強い")
+    } else {
+        (5, "非常に強い")
+    };
+
+    PasswordStrength {
+        score,
+        label: label.to_string(),
+        entropy: (entropy * 100.0).round() / 100.0,
+    }
+}
+
+pub fn generate_passwords(options: PasswordOptions) -> PasswordGenerateResult {
+    let charset = build_charset(&options);
+
+    if charset.is_empty() {
+        return PasswordGenerateResult {
+            success: false,
+            passwords: vec![],
+            error: Some("文字種を1つ以上選択してください".to_string()),
+        };
+    }
+
+    let charset_chars: Vec<char> = charset.chars().collect();
+    let charset_size = charset_chars.len();
+    let length = options.length.clamp(4, 128) as usize;
+    let count = options.count.clamp(1, 100);
+
+    let mut rng = rand::thread_rng();
+    let passwords: Vec<GeneratedPassword> = (0..count)
+        .map(|_| {
+            let password: String = (0..length)
+                .map(|_| {
+                    let idx = rng.gen_range(0..charset_size);
+                    charset_chars[idx]
+                })
+                .collect();
+
+            let strength = calculate_strength(&password, charset_size);
+            GeneratedPassword {
+                value: password,
+                strength,
+            }
+        })
+        .collect();
+
+    PasswordGenerateResult {
+        success: true,
+        passwords,
+        error: None,
+    }
+}
+
+pub fn generate_passphrases(options: PassphraseOptions) -> PasswordGenerateResult {
+    let word_count = options.word_count.clamp(2, 10) as usize;
+    let count = options.count.clamp(1, 100);
+
+    let mut rng = rand::thread_rng();
+    let passwords: Vec<GeneratedPassword> = (0..count)
+        .map(|_| {
+            let mut words: Vec<String> = WORD_LIST
+                .choose_multiple(&mut rng, word_count)
+                .map(|w| {
+                    if options.capitalize {
+                        let mut chars = w.chars();
+                        match chars.next() {
+                            Some(first) => first.to_uppercase().chain(chars).collect(),
+                            None => String::new(),
+                        }
+                    } else {
+                        w.to_string()
+                    }
+                })
+                .collect();
+
+            if options.include_number {
+                let num = rng.gen_range(0..100);
+                words.push(num.to_string());
+            }
+
+            let passphrase = words.join(&options.separator);
+
+            let pool_size = WORD_LIST.len();
+            let entropy = (word_count as f64) * (pool_size as f64).log2()
+                + if options.include_number {
+                    100_f64.log2()
+                } else {
+                    0.0
+                };
+
+            let (score, label) = if entropy < 40.0 {
+                (2, "弱い")
+            } else if entropy < 60.0 {
+                (3, "普通")
+            } else if entropy < 80.0 {
+                (4, "強い")
+            } else {
+                (5, "非常に強い")
+            };
+
+            let strength = PasswordStrength {
+                score,
+                label: label.to_string(),
+                entropy: (entropy * 100.0).round() / 100.0,
+            };
+
+            GeneratedPassword {
+                value: passphrase,
+                strength,
+            }
+        })
+        .collect();
+
+    PasswordGenerateResult {
+        success: true,
+        passwords,
+        error: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_password() {
+        let options = PasswordOptions {
+            length: 16,
+            include_lowercase: true,
+            include_uppercase: true,
+            include_digits: true,
+            include_symbols: false,
+            exclude_ambiguous: false,
+            custom_exclude: String::new(),
+            count: 1,
+        };
+
+        let result = generate_passwords(options);
+        assert!(result.success);
+        assert_eq!(result.passwords.len(), 1);
+        assert_eq!(result.passwords[0].value.len(), 16);
+    }
+
+    #[test]
+    fn test_generate_multiple_passwords() {
+        let options = PasswordOptions {
+            length: 12,
+            include_lowercase: true,
+            include_uppercase: true,
+            include_digits: true,
+            include_symbols: true,
+            exclude_ambiguous: false,
+            custom_exclude: String::new(),
+            count: 5,
+        };
+
+        let result = generate_passwords(options);
+        assert!(result.success);
+        assert_eq!(result.passwords.len(), 5);
+    }
+
+    #[test]
+    fn test_exclude_ambiguous() {
+        let options = PasswordOptions {
+            length: 100,
+            include_lowercase: true,
+            include_uppercase: true,
+            include_digits: true,
+            include_symbols: false,
+            exclude_ambiguous: true,
+            custom_exclude: String::new(),
+            count: 1,
+        };
+
+        let result = generate_passwords(options);
+        assert!(result.success);
+        let password = &result.passwords[0].value;
+        assert!(!password.contains('0'));
+        assert!(!password.contains('O'));
+        assert!(!password.contains('l'));
+        assert!(!password.contains('1'));
+        assert!(!password.contains('I'));
+    }
+
+    #[test]
+    fn test_generate_passphrase() {
+        let options = PassphraseOptions {
+            word_count: 4,
+            separator: "-".to_string(),
+            capitalize: true,
+            include_number: true,
+            count: 1,
+        };
+
+        let result = generate_passphrases(options);
+        assert!(result.success);
+        assert_eq!(result.passwords.len(), 1);
+        assert!(result.passwords[0].value.contains('-'));
+    }
+
+    #[test]
+    fn test_empty_charset() {
+        let options = PasswordOptions {
+            length: 16,
+            include_lowercase: false,
+            include_uppercase: false,
+            include_digits: false,
+            include_symbols: false,
+            exclude_ambiguous: false,
+            custom_exclude: String::new(),
+            count: 1,
+        };
+
+        let result = generate_passwords(options);
+        assert!(!result.success);
+        assert!(result.error.is_some());
+    }
+
+    #[test]
+    fn test_password_strength() {
+        let options = PasswordOptions {
+            length: 32,
+            include_lowercase: true,
+            include_uppercase: true,
+            include_digits: true,
+            include_symbols: true,
+            exclude_ambiguous: false,
+            custom_exclude: String::new(),
+            count: 1,
+        };
+
+        let result = generate_passwords(options);
+        assert!(result.success);
+        assert!(result.passwords[0].strength.score >= 4);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crate::components::image_compressor::ImageCompressor;
 use crate::components::image_editor::ImageEditor;
 use crate::components::kanban_board::KanbanBoardComponent;
 use crate::components::markdown_to_pdf::MarkdownToPdf;
+use crate::components::password_generator::PasswordGenerator;
 use crate::components::pdf_tools::PdfTools;
 use crate::components::uuid_generator::UuidGenerator;
 use wasm_bindgen::prelude::*;
@@ -24,6 +25,7 @@ enum Tab {
     MarkdownToPdf,
     KanbanBoard,
     UuidGenerator,
+    PasswordGenerator,
 }
 
 fn get_file_extension(path: &str) -> Option<String> {
@@ -243,6 +245,16 @@ pub fn app() -> Html {
                     <span class="tab-icon">{"🔑"}</span>
                     <span class="tab-label">{"UUID"}</span>
                 </button>
+                <button
+                    class={if *active_tab == Tab::PasswordGenerator { "tab-btn active" } else { "tab-btn" }}
+                    onclick={
+                        let on_click = on_tab_click.clone();
+                        Callback::from(move |_| on_click.emit(Tab::PasswordGenerator))
+                    }
+                >
+                    <span class="tab-icon">{"🔒"}</span>
+                    <span class="tab-label">{"Password"}</span>
+                </button>
             </div>
 
             <div class={if *active_tab == Tab::ImageCompressor { "tab-panel active" } else { "tab-panel" }}>
@@ -280,6 +292,9 @@ pub fn app() -> Html {
             </div>
             <div class={if *active_tab == Tab::UuidGenerator { "tab-panel active" } else { "tab-panel" }}>
                 <UuidGenerator />
+            </div>
+            <div class={if *active_tab == Tab::PasswordGenerator { "tab-panel active" } else { "tab-panel" }}>
+                <PasswordGenerator />
             </div>
         </main>
     }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -3,5 +3,6 @@ pub mod image_compressor;
 pub mod image_editor;
 pub mod kanban_board;
 pub mod markdown_to_pdf;
+pub mod password_generator;
 pub mod pdf_tools;
 pub mod uuid_generator;

--- a/src/components/password_generator.rs
+++ b/src/components/password_generator.rs
@@ -1,0 +1,636 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::window;
+use yew::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GeneratorMode {
+    Password,
+    Passphrase,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PasswordOptions {
+    length: u32,
+    include_lowercase: bool,
+    include_uppercase: bool,
+    include_digits: bool,
+    include_symbols: bool,
+    exclude_ambiguous: bool,
+    custom_exclude: String,
+    count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PassphraseOptions {
+    word_count: u32,
+    separator: String,
+    capitalize: bool,
+    include_number: bool,
+    count: u32,
+}
+
+#[derive(Serialize)]
+struct GeneratePasswordsArgs {
+    options: PasswordOptions,
+}
+
+#[derive(Serialize)]
+struct GeneratePassphrasesArgs {
+    options: PassphraseOptions,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PasswordStrength {
+    score: u32,
+    label: String,
+    entropy: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GeneratedPassword {
+    value: String,
+    strength: PasswordStrength,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PasswordGenerateResult {
+    success: bool,
+    passwords: Vec<GeneratedPassword>,
+    #[allow(dead_code)]
+    error: Option<String>,
+}
+
+#[derive(Clone, PartialEq)]
+struct DisplayPassword {
+    value: String,
+    strength: u32,
+    strength_label: String,
+    entropy: f64,
+    copied: bool,
+}
+
+#[function_component(PasswordGenerator)]
+pub fn password_generator() -> Html {
+    let mode = use_state(|| GeneratorMode::Password);
+    let length = use_state(|| 16u32);
+    let include_lowercase = use_state(|| true);
+    let include_uppercase = use_state(|| true);
+    let include_digits = use_state(|| true);
+    let include_symbols = use_state(|| true);
+    let exclude_ambiguous = use_state(|| false);
+    let custom_exclude = use_state(String::new);
+    let count = use_state(|| 1u32);
+
+    let word_count = use_state(|| 4u32);
+    let separator = use_state(|| "-".to_string());
+    let capitalize = use_state(|| true);
+    let include_number = use_state(|| true);
+
+    let generated_passwords = use_state(Vec::<DisplayPassword>::new);
+    let is_generating = use_state(|| false);
+    let copy_all_feedback = use_state(|| false);
+
+    let on_mode_change = {
+        let mode = mode.clone();
+        let generated_passwords = generated_passwords.clone();
+        Callback::from(move |new_mode: GeneratorMode| {
+            mode.set(new_mode);
+            generated_passwords.set(vec![]);
+        })
+    };
+
+    let on_length_change = {
+        let length = length.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            if let Ok(value) = input.value().parse::<u32>() {
+                length.set(value.clamp(4, 128));
+            }
+        })
+    };
+
+    let on_count_change = {
+        let count = count.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            if let Ok(value) = input.value().parse::<u32>() {
+                count.set(value.clamp(1, 100));
+            }
+        })
+    };
+
+    let on_custom_exclude_change = {
+        let custom_exclude = custom_exclude.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            custom_exclude.set(input.value());
+        })
+    };
+
+    let on_word_count_change = {
+        let word_count = word_count.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            if let Ok(value) = input.value().parse::<u32>() {
+                word_count.set(value.clamp(2, 10));
+            }
+        })
+    };
+
+    let on_separator_change = {
+        let separator = separator.clone();
+        Callback::from(move |e: Event| {
+            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+            separator.set(select.value());
+        })
+    };
+
+    let on_generate = {
+        let mode = mode.clone();
+        let length = length.clone();
+        let include_lowercase = include_lowercase.clone();
+        let include_uppercase = include_uppercase.clone();
+        let include_digits = include_digits.clone();
+        let include_symbols = include_symbols.clone();
+        let exclude_ambiguous = exclude_ambiguous.clone();
+        let custom_exclude = custom_exclude.clone();
+        let count = count.clone();
+        let word_count = word_count.clone();
+        let separator = separator.clone();
+        let capitalize = capitalize.clone();
+        let include_number = include_number.clone();
+        let generated_passwords = generated_passwords.clone();
+        let is_generating = is_generating.clone();
+
+        Callback::from(move |_| {
+            let mode_value = (*mode).clone();
+            let generated_passwords = generated_passwords.clone();
+            let is_generating = is_generating.clone();
+
+            is_generating.set(true);
+
+            match mode_value {
+                GeneratorMode::Password => {
+                    let options = PasswordOptions {
+                        length: *length,
+                        include_lowercase: *include_lowercase,
+                        include_uppercase: *include_uppercase,
+                        include_digits: *include_digits,
+                        include_symbols: *include_symbols,
+                        exclude_ambiguous: *exclude_ambiguous,
+                        custom_exclude: (*custom_exclude).clone(),
+                        count: *count,
+                    };
+
+                    spawn_local(async move {
+                        let args = serde_wasm_bindgen::to_value(&GeneratePasswordsArgs { options })
+                            .unwrap();
+                        let result = invoke("generate_passwords_cmd", args).await;
+
+                        if let Ok(res) =
+                            serde_wasm_bindgen::from_value::<PasswordGenerateResult>(result)
+                        {
+                            if res.success {
+                                let passwords: Vec<DisplayPassword> = res
+                                    .passwords
+                                    .into_iter()
+                                    .map(|p| DisplayPassword {
+                                        value: p.value,
+                                        strength: p.strength.score,
+                                        strength_label: p.strength.label,
+                                        entropy: p.strength.entropy,
+                                        copied: false,
+                                    })
+                                    .collect();
+                                generated_passwords.set(passwords);
+                            }
+                        }
+
+                        is_generating.set(false);
+                    });
+                }
+                GeneratorMode::Passphrase => {
+                    let options = PassphraseOptions {
+                        word_count: *word_count,
+                        separator: (*separator).clone(),
+                        capitalize: *capitalize,
+                        include_number: *include_number,
+                        count: *count,
+                    };
+
+                    spawn_local(async move {
+                        let args =
+                            serde_wasm_bindgen::to_value(&GeneratePassphrasesArgs { options })
+                                .unwrap();
+                        let result = invoke("generate_passphrases_cmd", args).await;
+
+                        if let Ok(res) =
+                            serde_wasm_bindgen::from_value::<PasswordGenerateResult>(result)
+                        {
+                            if res.success {
+                                let passwords: Vec<DisplayPassword> = res
+                                    .passwords
+                                    .into_iter()
+                                    .map(|p| DisplayPassword {
+                                        value: p.value,
+                                        strength: p.strength.score,
+                                        strength_label: p.strength.label,
+                                        entropy: p.strength.entropy,
+                                        copied: false,
+                                    })
+                                    .collect();
+                                generated_passwords.set(passwords);
+                            }
+                        }
+
+                        is_generating.set(false);
+                    });
+                }
+            }
+        })
+    };
+
+    let on_copy_single = {
+        let generated_passwords = generated_passwords.clone();
+        Callback::from(move |index: usize| {
+            let generated_passwords = generated_passwords.clone();
+            if let Some(password) = (*generated_passwords).get(index) {
+                let value = password.value.clone();
+                if let Some(win) = window() {
+                    let clipboard = win.navigator().clipboard();
+                    let generated_passwords_inner = generated_passwords.clone();
+                    spawn_local(async move {
+                        let _ = wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&value))
+                            .await;
+
+                        let mut passwords = (*generated_passwords_inner).clone();
+                        if let Some(p) = passwords.get_mut(index) {
+                            p.copied = true;
+                        }
+                        generated_passwords_inner.set(passwords);
+
+                        let generated_passwords_reset = generated_passwords_inner.clone();
+                        gloo_timers::callback::Timeout::new(2000, move || {
+                            let mut passwords = (*generated_passwords_reset).clone();
+                            if let Some(p) = passwords.get_mut(index) {
+                                p.copied = false;
+                            }
+                            generated_passwords_reset.set(passwords);
+                        })
+                        .forget();
+                    });
+                }
+            }
+        })
+    };
+
+    let on_copy_all = {
+        let generated_passwords = generated_passwords.clone();
+        let copy_all_feedback = copy_all_feedback.clone();
+        Callback::from(move |_| {
+            let passwords = (*generated_passwords).clone();
+            let copy_all_feedback = copy_all_feedback.clone();
+            if !passwords.is_empty() {
+                let all_values: String = passwords
+                    .iter()
+                    .map(|p| p.value.clone())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                if let Some(win) = window() {
+                    let clipboard = win.navigator().clipboard();
+                    spawn_local(async move {
+                        let _ =
+                            wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&all_values))
+                                .await;
+                        copy_all_feedback.set(true);
+
+                        let copy_all_feedback_reset = copy_all_feedback.clone();
+                        gloo_timers::callback::Timeout::new(2000, move || {
+                            copy_all_feedback_reset.set(false);
+                        })
+                        .forget();
+                    });
+                }
+            }
+        })
+    };
+
+    let strength_class = |score: u32| -> &'static str {
+        match score {
+            1 => "strength-very-weak",
+            2 => "strength-weak",
+            3 => "strength-medium",
+            4 => "strength-strong",
+            _ => "strength-very-strong",
+        }
+    };
+
+    html! {
+        <div class="password-generator">
+            // Mode Toggle
+            <div class="section">
+                <h3>{"生成モード"}</h3>
+                <div class="mode-toggle">
+                    <button
+                        class={classes!("mode-btn", (*mode == GeneratorMode::Password).then_some("active"))}
+                        onclick={{
+                            let on_mode_change = on_mode_change.clone();
+                            Callback::from(move |_| on_mode_change.emit(GeneratorMode::Password))
+                        }}
+                    >
+                        {"パスワード"}
+                    </button>
+                    <button
+                        class={classes!("mode-btn", (*mode == GeneratorMode::Passphrase).then_some("active"))}
+                        onclick={{
+                            let on_mode_change = on_mode_change.clone();
+                            Callback::from(move |_| on_mode_change.emit(GeneratorMode::Passphrase))
+                        }}
+                    >
+                        {"パスフレーズ"}
+                    </button>
+                </div>
+            </div>
+
+            // Password Options
+            if *mode == GeneratorMode::Password {
+                <div class="section password-options-section">
+                    <h3>{"パスワード設定"}</h3>
+
+                    <div class="password-options">
+                        <div class="form-group">
+                            <label>{"文字数"}</label>
+                            <div class="length-slider">
+                                <input
+                                    type="range"
+                                    min="4"
+                                    max="128"
+                                    value={length.to_string()}
+                                    oninput={on_length_change.clone()}
+                                />
+                                <input
+                                    type="number"
+                                    class="form-input length-input"
+                                    min="4"
+                                    max="128"
+                                    value={length.to_string()}
+                                    oninput={on_length_change}
+                                />
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label>{"文字種"}</label>
+                            <div class="char-type-options">
+                                <label class="checkbox-option-inline">
+                                    <input
+                                        type="checkbox"
+                                        checked={*include_lowercase}
+                                        onchange={{
+                                            let include_lowercase = include_lowercase.clone();
+                                            Callback::from(move |_| include_lowercase.set(!*include_lowercase))
+                                        }}
+                                    />
+                                    <span>{"小文字 (a-z)"}</span>
+                                </label>
+                                <label class="checkbox-option-inline">
+                                    <input
+                                        type="checkbox"
+                                        checked={*include_uppercase}
+                                        onchange={{
+                                            let include_uppercase = include_uppercase.clone();
+                                            Callback::from(move |_| include_uppercase.set(!*include_uppercase))
+                                        }}
+                                    />
+                                    <span>{"大文字 (A-Z)"}</span>
+                                </label>
+                                <label class="checkbox-option-inline">
+                                    <input
+                                        type="checkbox"
+                                        checked={*include_digits}
+                                        onchange={{
+                                            let include_digits = include_digits.clone();
+                                            Callback::from(move |_| include_digits.set(!*include_digits))
+                                        }}
+                                    />
+                                    <span>{"数字 (0-9)"}</span>
+                                </label>
+                                <label class="checkbox-option-inline">
+                                    <input
+                                        type="checkbox"
+                                        checked={*include_symbols}
+                                        onchange={{
+                                            let include_symbols = include_symbols.clone();
+                                            Callback::from(move |_| include_symbols.set(!*include_symbols))
+                                        }}
+                                    />
+                                    <span>{"記号 (!@#$...)"}</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="checkbox-option-inline exclude-option">
+                                <input
+                                    type="checkbox"
+                                    checked={*exclude_ambiguous}
+                                    onchange={{
+                                        let exclude_ambiguous = exclude_ambiguous.clone();
+                                        Callback::from(move |_| exclude_ambiguous.set(!*exclude_ambiguous))
+                                    }}
+                                />
+                                <span>{"紛らわしい文字を除外 (0, O, l, 1, I)"}</span>
+                            </label>
+                        </div>
+
+                        <div class="form-group">
+                            <label>{"追加除外文字"}</label>
+                            <input
+                                type="text"
+                                class="form-input"
+                                placeholder="除外する文字を入力..."
+                                value={(*custom_exclude).clone()}
+                                oninput={on_custom_exclude_change}
+                            />
+                        </div>
+
+                        <div class="form-group">
+                            <label>{"生成個数"}</label>
+                            <input
+                                type="number"
+                                class="form-input"
+                                min="1"
+                                max="100"
+                                value={count.to_string()}
+                                oninput={on_count_change.clone()}
+                            />
+                        </div>
+                    </div>
+                </div>
+            }
+
+            // Passphrase Options
+            if *mode == GeneratorMode::Passphrase {
+                <div class="section passphrase-options-section">
+                    <h3>{"パスフレーズ設定"}</h3>
+
+                    <div class="passphrase-options">
+                        <div class="form-group">
+                            <label>{"単語数"}</label>
+                            <div class="length-slider">
+                                <input
+                                    type="range"
+                                    min="2"
+                                    max="10"
+                                    value={word_count.to_string()}
+                                    oninput={on_word_count_change.clone()}
+                                />
+                                <input
+                                    type="number"
+                                    class="form-input length-input"
+                                    min="2"
+                                    max="10"
+                                    value={word_count.to_string()}
+                                    oninput={on_word_count_change}
+                                />
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label>{"区切り文字"}</label>
+                            <select class="form-select" onchange={on_separator_change}>
+                                <option value="-" selected={*separator == "-"}>{"ハイフン (-)"}</option>
+                                <option value="_" selected={*separator == "_"}>{"アンダースコア (_)"}</option>
+                                <option value="." selected={*separator == "."}>{"ドット (.)"}</option>
+                                <option value=" " selected={*separator == " "}>{"スペース"}</option>
+                                <option value="" selected={separator.is_empty()}>{"なし"}</option>
+                            </select>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="passphrase-toggles">
+                                <label class="checkbox-option-inline">
+                                    <input
+                                        type="checkbox"
+                                        checked={*capitalize}
+                                        onchange={{
+                                            let capitalize = capitalize.clone();
+                                            Callback::from(move |_| capitalize.set(!*capitalize))
+                                        }}
+                                    />
+                                    <span>{"単語の先頭を大文字"}</span>
+                                </label>
+                                <label class="checkbox-option-inline">
+                                    <input
+                                        type="checkbox"
+                                        checked={*include_number}
+                                        onchange={{
+                                            let include_number = include_number.clone();
+                                            Callback::from(move |_| include_number.set(!*include_number))
+                                        }}
+                                    />
+                                    <span>{"数字を追加"}</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label>{"生成個数"}</label>
+                            <input
+                                type="number"
+                                class="form-input"
+                                min="1"
+                                max="100"
+                                value={count.to_string()}
+                                oninput={on_count_change}
+                            />
+                        </div>
+                    </div>
+                </div>
+            }
+
+            // Generate Button
+            <button
+                class="primary-btn generate-btn"
+                onclick={on_generate}
+                disabled={*is_generating}
+            >
+                if *is_generating {
+                    <span class="processing">
+                        <span class="spinner"></span>
+                        {"生成中..."}
+                    </span>
+                } else {
+                    if *mode == GeneratorMode::Password {
+                        {"パスワードを生成"}
+                    } else {
+                        {"パスフレーズを生成"}
+                    }
+                }
+            </button>
+
+            // Generated Passwords
+            if !generated_passwords.is_empty() {
+                <div class="section password-results-section">
+                    <div class="password-results-header">
+                        <h3>{format!("生成結果 ({} 件)", generated_passwords.len())}</h3>
+                        <button
+                            class={classes!("secondary-btn", "copy-all-btn", (*copy_all_feedback).then_some("copied"))}
+                            onclick={on_copy_all}
+                        >
+                            if *copy_all_feedback {
+                                {"✓ コピー完了"}
+                            } else {
+                                {"すべてコピー"}
+                            }
+                        </button>
+                    </div>
+                    <div class="password-list">
+                        { for (*generated_passwords).iter().enumerate().map(|(index, password)| {
+                            let on_copy = {
+                                let on_copy_single = on_copy_single.clone();
+                                Callback::from(move |_| on_copy_single.emit(index))
+                            };
+                            html! {
+                                <div class="password-item">
+                                    <div class="password-content">
+                                        <code class="password-value">{&password.value}</code>
+                                        <div class="password-meta">
+                                            <span class={classes!("strength-badge", strength_class(password.strength))}>
+                                                {&password.strength_label}
+                                            </span>
+                                            <span class="entropy-value">
+                                                {format!("エントロピー: {:.1} bits", password.entropy)}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <button
+                                        class={classes!("copy-btn", password.copied.then_some("copied"))}
+                                        onclick={on_copy}
+                                    >
+                                        if password.copied {
+                                            {"✓"}
+                                        } else {
+                                            {"📋"}
+                                        }
+                                    </button>
+                                </div>
+                            }
+                        })}
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -2257,6 +2257,214 @@ body {
   font-family: var(--font-mono);
 }
 
+/* ===== Password Generator ===== */
+.password-generator {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.password-generator h2 {
+  display: none;
+}
+
+.password-options,
+.passphrase-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.length-slider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.length-slider input[type="range"] {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-overlay);
+  appearance: none;
+  cursor: pointer;
+}
+
+.length-slider input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  box-shadow: 0 0 10px var(--accent-primary-glow);
+  cursor: pointer;
+  transition: transform var(--duration-fast) var(--ease-spring);
+}
+
+.length-slider input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+
+.length-input {
+  width: 80px;
+  text-align: center;
+}
+
+.char-type-options {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-2);
+}
+
+@media (max-width: 640px) {
+  .char-type-options {
+    grid-template-columns: 1fr;
+  }
+}
+
+.checkbox-option-inline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.checkbox-option-inline:hover {
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
+}
+
+.checkbox-option-inline input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent-primary);
+  cursor: pointer;
+}
+
+.checkbox-option-inline span {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.exclude-option {
+  margin-top: var(--space-2);
+}
+
+.passphrase-toggles {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.passphrase-toggles .checkbox-option-inline {
+  flex: 1;
+  min-width: 150px;
+}
+
+.password-results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.password-results-header h3 {
+  margin: 0;
+}
+
+.password-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.password-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.password-item:hover {
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
+}
+
+.password-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.password-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--accent-primary);
+  word-break: break-all;
+  user-select: all;
+}
+
+.password-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.strength-badge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.strength-very-weak {
+  background: var(--error-dim);
+  color: var(--error);
+}
+
+.strength-weak {
+  background: rgba(255, 107, 53, 0.15);
+  color: var(--accent-secondary);
+}
+
+.strength-medium {
+  background: var(--warning-dim);
+  color: var(--warning);
+}
+
+.strength-strong {
+  background: var(--accent-primary-dim);
+  color: var(--accent-primary);
+}
+
+.strength-very-strong {
+  background: var(--success-dim);
+  color: var(--success);
+}
+
+.entropy-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
 /* ===== Utility Classes ===== */
 .container > h1 {
   font-family: var(--font-display);


### PR DESCRIPTION
## 概要
安全なランダムパスワード生成機能を実装しました。

## 変更の種類
- [x] 新機能

## 関連Issue
Fixes #30

## 変更内容
- パスワード生成機能（ランダム文字列）
  - 文字数指定（4-128文字）
  - 文字種選択（大文字/小文字/数字/記号）
  - 紛らわしい文字の除外（0, O, l, 1, I）
  - カスタム除外文字指定
  - 複数パスワードの一括生成（最大100件）
- パスフレーズ生成機能（単語ベース）
  - 単語数指定（2-10単語）
  - 区切り文字選択（ハイフン/アンダースコア/ドット/スペース/なし）
  - 先頭大文字オプション
  - 数字追加オプション
- パスワード強度表示（5段階 + エントロピー値）
- ワンクリックコピー（個別/一括）

## テスト
- [x] 手動テスト実施
- [x] ユニットテスト追加/更新（6件のテスト追加）
- [x] 既存テストが通ることを確認

## チェックリスト
- [x] コードがプロジェクトのスタイルに従っている
- [x] 自己レビューを実施した
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がないか確認した