### PR TITLE
feat: テキスト差分比較機能を実装

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,4 +34,5 @@ uuid = { version = "1", features = ["v4", "v7"] }
 pulldown-cmark = "0.12"
 regex = "1"
 rand = "0.8"
+similar = "2"
 

--- a/src-tauri/src/kanban.rs
+++ b/src-tauri/src/kanban.rs
@@ -126,6 +126,7 @@ pub fn create_task(
     Ok(task)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn update_task(
     app: &AppHandle,
     task_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod kanban;
 mod markdown_to_pdf;
 mod password_generator;
 mod pdf_tools;
+mod text_diff;
 mod unit_converter;
 mod uuid_generator;
 
@@ -33,6 +34,7 @@ use pdf_tools::{
     get_pdf_info, merge_pdfs, split_pdf_by_pages, split_pdf_by_range, PdfInfo, PdfMergeResult,
     PdfSplitResult,
 };
+use text_diff::{compute_diff, get_file_info, DiffMode, DiffResult, FileInfo};
 use unit_converter::{
     convert_area, convert_data_size, convert_length, convert_temperature, convert_time,
     convert_volume, convert_weight, AreaUnit, ConversionResult, DataSizeUnit, LengthUnit,
@@ -148,6 +150,7 @@ fn create_task_cmd(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 fn update_task_cmd(
     app: tauri::AppHandle,
     task_id: String,
@@ -306,6 +309,16 @@ fn convert_volume_cmd(value: f64, from: VolumeUnit, to: VolumeUnit) -> Conversio
     convert_volume(value, from, to)
 }
 
+#[tauri::command]
+fn compute_diff_cmd(old_text: String, new_text: String, mode: DiffMode) -> DiffResult {
+    compute_diff(&old_text, &new_text, mode)
+}
+
+#[tauri::command]
+fn get_text_file_info_cmd(path: String) -> Result<FileInfo, String> {
+    get_file_info(&path)
+}
+
 use tauri::{Emitter, WindowEvent};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -360,7 +373,9 @@ pub fn run() {
             convert_temperature_cmd,
             convert_time_cmd,
             convert_area_cmd,
-            convert_volume_cmd
+            convert_volume_cmd,
+            compute_diff_cmd,
+            get_text_file_info_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/text_diff.rs
+++ b/src-tauri/src/text_diff.rs
@@ -1,0 +1,283 @@
+use serde::{Deserialize, Serialize};
+use similar::{ChangeTag, TextDiff};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum DiffMode {
+    Line,
+    Word,
+    Character,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffChange {
+    pub tag: String,
+    pub value: String,
+    pub old_index: Option<usize>,
+    pub new_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LineDiff {
+    pub line_number_old: Option<usize>,
+    pub line_number_new: Option<usize>,
+    pub tag: String,
+    pub content: String,
+    pub inline_changes: Vec<InlineChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineChange {
+    pub tag: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffResult {
+    pub success: bool,
+    pub lines: Vec<LineDiff>,
+    pub stats: DiffStats,
+    pub unified_diff: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffStats {
+    pub additions: usize,
+    pub deletions: usize,
+    pub modifications: usize,
+    pub unchanged: usize,
+    pub total_lines_old: usize,
+    pub total_lines_new: usize,
+}
+
+pub fn compute_diff(old_text: &str, new_text: &str, mode: DiffMode) -> DiffResult {
+    let diff = TextDiff::from_lines(old_text, new_text);
+
+    let mut lines: Vec<LineDiff> = Vec::new();
+    let mut old_line_num = 1usize;
+    let mut new_line_num = 1usize;
+    let mut additions = 0usize;
+    let mut deletions = 0usize;
+    let mut unchanged = 0usize;
+
+    for change in diff.iter_all_changes() {
+        let (tag_str, line_old, line_new) = match change.tag() {
+            ChangeTag::Delete => {
+                deletions += 1;
+                let ln = old_line_num;
+                old_line_num += 1;
+                ("delete", Some(ln), None)
+            }
+            ChangeTag::Insert => {
+                additions += 1;
+                let ln = new_line_num;
+                new_line_num += 1;
+                ("insert", None, Some(ln))
+            }
+            ChangeTag::Equal => {
+                unchanged += 1;
+                let lo = old_line_num;
+                let ln = new_line_num;
+                old_line_num += 1;
+                new_line_num += 1;
+                ("equal", Some(lo), Some(ln))
+            }
+        };
+
+        let content = change.value().to_string();
+        let _ = &mode; // Suppress unused warning
+        let inline_changes = Vec::new();
+
+        lines.push(LineDiff {
+            line_number_old: line_old,
+            line_number_new: line_new,
+            tag: tag_str.to_string(),
+            content,
+            inline_changes,
+        });
+    }
+
+    let total_lines_old = old_text.lines().count().max(1);
+    let total_lines_new = new_text.lines().count().max(1);
+
+    let unified_diff = generate_unified_diff(old_text, new_text);
+
+    DiffResult {
+        success: true,
+        lines,
+        stats: DiffStats {
+            additions,
+            deletions,
+            modifications: 0,
+            unchanged,
+            total_lines_old,
+            total_lines_new,
+        },
+        unified_diff,
+        error: None,
+    }
+}
+
+#[allow(dead_code)]
+pub fn compute_inline_diff(old_line: &str, new_line: &str, mode: DiffMode) -> Vec<InlineChange> {
+    let changes: Vec<InlineChange> = match mode {
+        DiffMode::Word => {
+            let diff = TextDiff::from_words(old_line, new_line);
+            diff.iter_all_changes()
+                .map(|change| {
+                    let tag = match change.tag() {
+                        ChangeTag::Delete => "delete",
+                        ChangeTag::Insert => "insert",
+                        ChangeTag::Equal => "equal",
+                    };
+                    InlineChange {
+                        tag: tag.to_string(),
+                        value: change.value().to_string(),
+                    }
+                })
+                .collect()
+        }
+        DiffMode::Character => {
+            let diff = TextDiff::from_chars(old_line, new_line);
+            diff.iter_all_changes()
+                .map(|change| {
+                    let tag = match change.tag() {
+                        ChangeTag::Delete => "delete",
+                        ChangeTag::Insert => "insert",
+                        ChangeTag::Equal => "equal",
+                    };
+                    InlineChange {
+                        tag: tag.to_string(),
+                        value: change.value().to_string(),
+                    }
+                })
+                .collect()
+        }
+        DiffMode::Line => Vec::new(),
+    };
+    changes
+}
+
+fn generate_unified_diff(old_text: &str, new_text: &str) -> String {
+    let diff = TextDiff::from_lines(old_text, new_text);
+    let mut output = String::new();
+
+    output.push_str("--- a/original\n");
+    output.push_str("+++ b/modified\n");
+
+    for hunk in diff.unified_diff().context_radius(3).iter_hunks() {
+        output.push_str(&format!("{}", hunk));
+    }
+
+    output
+}
+
+pub fn read_text_file(path: &str) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileInfo {
+    pub path: String,
+    pub name: String,
+    pub size: u64,
+    pub content: String,
+}
+
+pub fn get_file_info(path: &str) -> Result<FileInfo, String> {
+    let metadata =
+        std::fs::metadata(path).map_err(|e| format!("Failed to get file info: {}", e))?;
+    let content = read_text_file(path)?;
+    let name = std::path::Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string());
+
+    Ok(FileInfo {
+        path: path.to_string(),
+        name,
+        size: metadata.len(),
+        content,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_diff_no_changes() {
+        let text = "line1\nline2\nline3\n";
+        let result = compute_diff(text, text, DiffMode::Line);
+
+        assert!(result.success);
+        assert_eq!(result.stats.additions, 0);
+        assert_eq!(result.stats.deletions, 0);
+        assert_eq!(result.stats.unchanged, 3);
+    }
+
+    #[test]
+    fn test_compute_diff_with_additions() {
+        let old = "line1\nline2\n";
+        let new = "line1\nline2\nline3\n";
+        let result = compute_diff(old, new, DiffMode::Line);
+
+        assert!(result.success);
+        assert_eq!(result.stats.additions, 1);
+        assert_eq!(result.stats.deletions, 0);
+        assert_eq!(result.stats.unchanged, 2);
+    }
+
+    #[test]
+    fn test_compute_diff_with_deletions() {
+        let old = "line1\nline2\nline3\n";
+        let new = "line1\nline3\n";
+        let result = compute_diff(old, new, DiffMode::Line);
+
+        assert!(result.success);
+        assert_eq!(result.stats.deletions, 1);
+        assert_eq!(result.stats.unchanged, 2);
+    }
+
+    #[test]
+    fn test_compute_diff_with_modifications() {
+        let old = "line1\nline2\nline3\n";
+        let new = "line1\nmodified\nline3\n";
+        let result = compute_diff(old, new, DiffMode::Line);
+
+        assert!(result.success);
+        assert_eq!(result.stats.additions, 1);
+        assert_eq!(result.stats.deletions, 1);
+        assert_eq!(result.stats.unchanged, 2);
+    }
+
+    #[test]
+    fn test_unified_diff_format() {
+        let old = "line1\nline2\n";
+        let new = "line1\nline3\n";
+        let result = compute_diff(old, new, DiffMode::Line);
+
+        assert!(result.unified_diff.contains("--- a/original"));
+        assert!(result.unified_diff.contains("+++ b/modified"));
+        assert!(result.unified_diff.contains("-line2"));
+        assert!(result.unified_diff.contains("+line3"));
+    }
+
+    #[test]
+    fn test_empty_texts() {
+        let result = compute_diff("", "", DiffMode::Line);
+
+        assert!(result.success);
+        assert_eq!(result.stats.additions, 0);
+        assert_eq!(result.stats.deletions, 0);
+        assert_eq!(result.stats.unchanged, 0);
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -5,5 +5,6 @@ pub mod kanban_board;
 pub mod markdown_to_pdf;
 pub mod password_generator;
 pub mod pdf_tools;
+pub mod text_diff;
 pub mod unit_converter;
 pub mod uuid_generator;

--- a/src/components/text_diff.rs
+++ b/src/components/text_diff.rs
@@ -1,0 +1,638 @@
+use gloo_timers::callback::Timeout;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::window;
+use yew::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DiffMode {
+    Line,
+    Word,
+    Character,
+}
+
+impl DiffMode {
+    fn label(&self) -> &'static str {
+        match self {
+            DiffMode::Line => "Line",
+            DiffMode::Word => "Word",
+            DiffMode::Character => "Character",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ViewMode {
+    SideBySide,
+    Unified,
+    DiffOnly,
+}
+
+impl ViewMode {
+    fn label(&self) -> &'static str {
+        match self {
+            ViewMode::SideBySide => "Side by Side",
+            ViewMode::Unified => "Unified",
+            ViewMode::DiffOnly => "Diff Only",
+        }
+    }
+
+    fn icon(&self) -> &'static str {
+        match self {
+            ViewMode::SideBySide => "||",
+            ViewMode::Unified => "=",
+            ViewMode::DiffOnly => "+-",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InlineChange {
+    tag: String,
+    value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LineDiff {
+    line_number_old: Option<usize>,
+    line_number_new: Option<usize>,
+    tag: String,
+    content: String,
+    #[allow(dead_code)]
+    inline_changes: Vec<InlineChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DiffStats {
+    additions: usize,
+    deletions: usize,
+    #[allow(dead_code)]
+    modifications: usize,
+    unchanged: usize,
+    total_lines_old: usize,
+    total_lines_new: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DiffResult {
+    success: bool,
+    lines: Vec<LineDiff>,
+    stats: DiffStats,
+    unified_diff: String,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FileInfo {
+    path: String,
+    name: String,
+    size: u64,
+    content: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ComputeDiffArgs {
+    old_text: String,
+    new_text: String,
+    mode: DiffMode,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GetFileInfoArgs {
+    path: String,
+}
+
+#[derive(Properties, PartialEq)]
+pub struct Props {
+    #[prop_or_default]
+    pub dropped_file: Option<String>,
+    #[prop_or_default]
+    pub on_file_processed: Callback<()>,
+}
+
+#[function_component(TextDiffComponent)]
+pub fn text_diff(props: &Props) -> Html {
+    let old_text = use_state(String::new);
+    let new_text = use_state(String::new);
+    let old_file_name = use_state(|| Option::<String>::None);
+    let new_file_name = use_state(|| Option::<String>::None);
+    let diff_result = use_state(|| Option::<DiffResult>::None);
+    let is_comparing = use_state(|| false);
+    let diff_mode = use_state(|| DiffMode::Line);
+    let view_mode = use_state(|| ViewMode::SideBySide);
+    let copied = use_state(|| false);
+    let error_message = use_state(|| Option::<String>::None);
+
+    // Handle dropped file
+    {
+        let dropped_file = props.dropped_file.clone();
+        let old_text = old_text.clone();
+        let old_file_name = old_file_name.clone();
+        let new_text = new_text.clone();
+        let new_file_name = new_file_name.clone();
+        let on_file_processed = props.on_file_processed.clone();
+        let error_message = error_message.clone();
+
+        use_effect_with(dropped_file, move |dropped_file| {
+            if let Some(path) = dropped_file.clone() {
+                let old_text = old_text.clone();
+                let old_file_name = old_file_name.clone();
+                let new_text = new_text.clone();
+                let new_file_name = new_file_name.clone();
+                let on_file_processed = on_file_processed.clone();
+                let error_message = error_message.clone();
+
+                spawn_local(async move {
+                    let args = serde_wasm_bindgen::to_value(&GetFileInfoArgs { path }).unwrap();
+                    let result = invoke("get_text_file_info_cmd", args).await;
+
+                    if let Ok(file_info) = serde_wasm_bindgen::from_value::<FileInfo>(result) {
+                        if (*old_text).is_empty() {
+                            old_text.set(file_info.content);
+                            old_file_name.set(Some(file_info.name));
+                        } else if (*new_text).is_empty() {
+                            new_text.set(file_info.content);
+                            new_file_name.set(Some(file_info.name));
+                        } else {
+                            old_text.set((*new_text).clone());
+                            old_file_name.set((*new_file_name).clone());
+                            new_text.set(file_info.content);
+                            new_file_name.set(Some(file_info.name));
+                        }
+                        error_message.set(None);
+                    } else {
+                        error_message.set(Some("Failed to load file".to_string()));
+                    }
+                    on_file_processed.emit(());
+                });
+            }
+            || {}
+        });
+    }
+
+    let on_compare = {
+        let old_text = old_text.clone();
+        let new_text = new_text.clone();
+        let diff_result = diff_result.clone();
+        let is_comparing = is_comparing.clone();
+        let diff_mode = diff_mode.clone();
+        let error_message = error_message.clone();
+
+        Callback::from(move |_| {
+            if (*old_text).is_empty() && (*new_text).is_empty() {
+                return;
+            }
+
+            let old_text_val = (*old_text).clone();
+            let new_text_val = (*new_text).clone();
+            let diff_result = diff_result.clone();
+            let is_comparing = is_comparing.clone();
+            let mode = (*diff_mode).clone();
+            let error_message = error_message.clone();
+
+            is_comparing.set(true);
+
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&ComputeDiffArgs {
+                    old_text: old_text_val,
+                    new_text: new_text_val,
+                    mode,
+                })
+                .unwrap();
+
+                let result = invoke("compute_diff_cmd", args).await;
+
+                if let Ok(res) = serde_wasm_bindgen::from_value::<DiffResult>(result) {
+                    if res.success {
+                        diff_result.set(Some(res));
+                        error_message.set(None);
+                    } else {
+                        error_message.set(res.error);
+                    }
+                } else {
+                    error_message.set(Some("Failed to compute diff".to_string()));
+                }
+                is_comparing.set(false);
+            });
+        })
+    };
+
+    let on_old_text_change = {
+        let old_text = old_text.clone();
+        Callback::from(move |e: InputEvent| {
+            let textarea: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            old_text.set(textarea.value());
+        })
+    };
+
+    let on_new_text_change = {
+        let new_text = new_text.clone();
+        Callback::from(move |e: InputEvent| {
+            let textarea: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            new_text.set(textarea.value());
+        })
+    };
+
+    let on_diff_mode_change = {
+        let diff_mode = diff_mode.clone();
+        Callback::from(move |mode: DiffMode| {
+            diff_mode.set(mode);
+        })
+    };
+
+    let on_view_mode_change = {
+        let view_mode = view_mode.clone();
+        Callback::from(move |mode: ViewMode| {
+            view_mode.set(mode);
+        })
+    };
+
+    let on_copy_unified = {
+        let diff_result = diff_result.clone();
+        let copied = copied.clone();
+
+        Callback::from(move |_| {
+            if let Some(ref result) = *diff_result {
+                if let Some(win) = window() {
+                    let clipboard = win.navigator().clipboard();
+                    let text = result.unified_diff.clone();
+                    let copied = copied.clone();
+
+                    spawn_local(async move {
+                        let _ =
+                            wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&text)).await;
+                        copied.set(true);
+
+                        Timeout::new(2000, move || {
+                            copied.set(false);
+                        })
+                        .forget();
+                    });
+                }
+            }
+        })
+    };
+
+    let on_clear = {
+        let old_text = old_text.clone();
+        let new_text = new_text.clone();
+        let old_file_name = old_file_name.clone();
+        let new_file_name = new_file_name.clone();
+        let diff_result = diff_result.clone();
+        let error_message = error_message.clone();
+
+        Callback::from(move |_| {
+            old_text.set(String::new());
+            new_text.set(String::new());
+            old_file_name.set(None);
+            new_file_name.set(None);
+            diff_result.set(None);
+            error_message.set(None);
+        })
+    };
+
+    let on_swap = {
+        let old_text = old_text.clone();
+        let new_text = new_text.clone();
+        let old_file_name = old_file_name.clone();
+        let new_file_name = new_file_name.clone();
+
+        Callback::from(move |_| {
+            let temp_text = (*old_text).clone();
+            let temp_name = (*old_file_name).clone();
+            old_text.set((*new_text).clone());
+            old_file_name.set((*new_file_name).clone());
+            new_text.set(temp_text);
+            new_file_name.set(temp_name);
+        })
+    };
+
+    html! {
+        <div class="text-diff-container">
+            <div class="section diff-header">
+                <h3>{"// DIFF OPTIONS"}</h3>
+                <div class="diff-controls">
+                    <div class="control-group">
+                        <label class="control-label">{"Diff Mode"}</label>
+                        <div class="mode-buttons">
+                            {
+                                [DiffMode::Line, DiffMode::Word, DiffMode::Character].iter().map(|mode| {
+                                    let is_active = *diff_mode == *mode;
+                                    let on_click = on_diff_mode_change.clone();
+                                    let m = mode.clone();
+                                    html! {
+                                        <button
+                                            class={classes!("mode-btn", is_active.then_some("active"))}
+                                            onclick={Callback::from(move |_| on_click.emit(m.clone()))}
+                                        >
+                                            {mode.label()}
+                                        </button>
+                                    }
+                                }).collect::<Html>()
+                            }
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label">{"View Mode"}</label>
+                        <div class="mode-buttons">
+                            {
+                                [ViewMode::SideBySide, ViewMode::Unified, ViewMode::DiffOnly].iter().map(|mode| {
+                                    let is_active = *view_mode == *mode;
+                                    let on_click = on_view_mode_change.clone();
+                                    let m = mode.clone();
+                                    html! {
+                                        <button
+                                            class={classes!("mode-btn", is_active.then_some("active"))}
+                                            onclick={Callback::from(move |_| on_click.emit(m.clone()))}
+                                        >
+                                            <span class="mode-icon">{mode.icon()}</span>
+                                            <span>{mode.label()}</span>
+                                        </button>
+                                    }
+                                }).collect::<Html>()
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="section input-section">
+                <div class="input-panels">
+                    <div class="input-panel">
+                        <div class="panel-header">
+                            <span class="panel-title">
+                                {"Original"}
+                                if let Some(ref name) = *old_file_name {
+                                    <span class="file-name">{format!(" ({})", name)}</span>
+                                }
+                            </span>
+                            <span class="line-count">{format!("{} lines", (*old_text).lines().count())}</span>
+                        </div>
+                        <textarea
+                            class="diff-textarea"
+                            placeholder="Paste original text here or drop a file..."
+                            value={(*old_text).clone()}
+                            oninput={on_old_text_change}
+                        />
+                    </div>
+                    <div class="swap-button-container">
+                        <button class="swap-btn" onclick={on_swap} title="Swap texts">
+                            {"<->"}
+                        </button>
+                    </div>
+                    <div class="input-panel">
+                        <div class="panel-header">
+                            <span class="panel-title">
+                                {"Modified"}
+                                if let Some(ref name) = *new_file_name {
+                                    <span class="file-name">{format!(" ({})", name)}</span>
+                                }
+                            </span>
+                            <span class="line-count">{format!("{} lines", (*new_text).lines().count())}</span>
+                        </div>
+                        <textarea
+                            class="diff-textarea"
+                            placeholder="Paste modified text here or drop a file..."
+                            value={(*new_text).clone()}
+                            oninput={on_new_text_change}
+                        />
+                    </div>
+                </div>
+                <div class="action-buttons">
+                    <button
+                        class="primary-btn"
+                        onclick={on_compare.clone()}
+                        disabled={*is_comparing || ((*old_text).is_empty() && (*new_text).is_empty())}
+                    >
+                        if *is_comparing {
+                            <span class="spinner"></span>
+                            <span>{"Comparing..."}</span>
+                        } else {
+                            <span>{"Compare"}</span>
+                        }
+                    </button>
+                    <button class="secondary-btn" onclick={on_clear}>
+                        {"Clear All"}
+                    </button>
+                </div>
+            </div>
+
+            if let Some(ref error) = *error_message {
+                <div class="section error-section">
+                    <p class="error-message">{error}</p>
+                </div>
+            }
+
+            if let Some(ref result) = *diff_result {
+                <div class="section stats-section">
+                    <h3>{"// DIFF STATISTICS"}</h3>
+                    <div class="stats-grid">
+                        <div class="stat-item additions">
+                            <span class="stat-value">{format!("+{}", result.stats.additions)}</span>
+                            <span class="stat-label">{"Additions"}</span>
+                        </div>
+                        <div class="stat-item deletions">
+                            <span class="stat-value">{format!("-{}", result.stats.deletions)}</span>
+                            <span class="stat-label">{"Deletions"}</span>
+                        </div>
+                        <div class="stat-item unchanged">
+                            <span class="stat-value">{result.stats.unchanged}</span>
+                            <span class="stat-label">{"Unchanged"}</span>
+                        </div>
+                        <div class="stat-item total">
+                            <span class="stat-value">{format!("{} -> {}", result.stats.total_lines_old, result.stats.total_lines_new)}</span>
+                            <span class="stat-label">{"Lines"}</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section result-section">
+                    <div class="result-header">
+                        <h3>{"// DIFF RESULT"}</h3>
+                        <button
+                            class={classes!("copy-btn", (*copied).then_some("copied"))}
+                            onclick={on_copy_unified}
+                        >
+                            if *copied {
+                                {"Copied!"}
+                            } else {
+                                {"Copy Unified Diff"}
+                            }
+                        </button>
+                    </div>
+
+                    {
+                        match *view_mode {
+                            ViewMode::SideBySide => render_side_by_side(&result.lines),
+                            ViewMode::Unified => render_unified(&result.lines),
+                            ViewMode::DiffOnly => render_diff_only(&result.lines),
+                        }
+                    }
+                </div>
+            }
+        </div>
+    }
+}
+
+fn render_side_by_side(lines: &[LineDiff]) -> Html {
+    let mut old_lines: Vec<&LineDiff> = Vec::new();
+    let mut new_lines: Vec<&LineDiff> = Vec::new();
+
+    for line in lines {
+        match line.tag.as_str() {
+            "delete" => old_lines.push(line),
+            "insert" => new_lines.push(line),
+            "equal" => {
+                old_lines.push(line);
+                new_lines.push(line);
+            }
+            _ => {}
+        }
+    }
+
+    let max_len = old_lines.len().max(new_lines.len());
+
+    html! {
+        <div class="diff-view side-by-side">
+            <div class="diff-panel old-panel">
+                <div class="diff-panel-header">{"Original"}</div>
+                <div class="diff-lines">
+                    { for (0..max_len).map(|i| {
+                        if let Some(line) = old_lines.get(i) {
+                            let class = match line.tag.as_str() {
+                                "delete" => "diff-line delete",
+                                _ => "diff-line equal",
+                            };
+                            html! {
+                                <div class={class}>
+                                    <span class="line-number">
+                                        {line.line_number_old.map(|n| n.to_string()).unwrap_or_default()}
+                                    </span>
+                                    <span class="line-content">{&line.content}</span>
+                                </div>
+                            }
+                        } else {
+                            html! {
+                                <div class="diff-line empty">
+                                    <span class="line-number"></span>
+                                    <span class="line-content"></span>
+                                </div>
+                            }
+                        }
+                    })}
+                </div>
+            </div>
+            <div class="diff-panel new-panel">
+                <div class="diff-panel-header">{"Modified"}</div>
+                <div class="diff-lines">
+                    { for (0..max_len).map(|i| {
+                        if let Some(line) = new_lines.get(i) {
+                            let class = match line.tag.as_str() {
+                                "insert" => "diff-line insert",
+                                _ => "diff-line equal",
+                            };
+                            html! {
+                                <div class={class}>
+                                    <span class="line-number">
+                                        {line.line_number_new.map(|n| n.to_string()).unwrap_or_default()}
+                                    </span>
+                                    <span class="line-content">{&line.content}</span>
+                                </div>
+                            }
+                        } else {
+                            html! {
+                                <div class="diff-line empty">
+                                    <span class="line-number"></span>
+                                    <span class="line-content"></span>
+                                </div>
+                            }
+                        }
+                    })}
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_unified(lines: &[LineDiff]) -> Html {
+    html! {
+        <div class="diff-view unified">
+            <div class="diff-lines">
+                { for lines.iter().map(|line| {
+                    let (class, prefix) = match line.tag.as_str() {
+                        "delete" => ("diff-line delete", "-"),
+                        "insert" => ("diff-line insert", "+"),
+                        _ => ("diff-line equal", " "),
+                    };
+                    html! {
+                        <div class={class}>
+                            <span class="line-number old">
+                                {line.line_number_old.map(|n| n.to_string()).unwrap_or_default()}
+                            </span>
+                            <span class="line-number new">
+                                {line.line_number_new.map(|n| n.to_string()).unwrap_or_default()}
+                            </span>
+                            <span class="line-prefix">{prefix}</span>
+                            <span class="line-content">{&line.content}</span>
+                        </div>
+                    }
+                })}
+            </div>
+        </div>
+    }
+}
+
+fn render_diff_only(lines: &[LineDiff]) -> Html {
+    let diff_lines: Vec<&LineDiff> = lines.iter().filter(|l| l.tag != "equal").collect();
+
+    if diff_lines.is_empty() {
+        return html! {
+            <div class="diff-view diff-only">
+                <div class="no-diff-message">
+                    {"No differences found"}
+                </div>
+            </div>
+        };
+    }
+
+    html! {
+        <div class="diff-view diff-only">
+            <div class="diff-lines">
+                { for diff_lines.iter().map(|line| {
+                    let (class, prefix) = match line.tag.as_str() {
+                        "delete" => ("diff-line delete", "-"),
+                        "insert" => ("diff-line insert", "+"),
+                        _ => ("diff-line equal", " "),
+                    };
+                    html! {
+                        <div class={class}>
+                            <span class="line-number old">
+                                {line.line_number_old.map(|n| n.to_string()).unwrap_or_default()}
+                            </span>
+                            <span class="line-number new">
+                                {line.line_number_new.map(|n| n.to_string()).unwrap_or_default()}
+                            </span>
+                            <span class="line-prefix">{prefix}</span>
+                            <span class="line-content">{&line.content}</span>
+                        </div>
+                    }
+                })}
+            </div>
+        </div>
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -2649,6 +2649,422 @@ body {
   font-weight: 600;
 }
 
+/* ===== Text Diff Component ===== */
+.text-diff-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.text-diff-container .diff-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.text-diff-container .diff-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+}
+
+.text-diff-container .control-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.text-diff-container .control-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.text-diff-container .mode-buttons {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.text-diff-container .mode-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.text-diff-container .mode-btn:hover {
+  background: var(--bg-overlay);
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+
+.text-diff-container .mode-btn.active {
+  background: var(--accent-primary-dim);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.text-diff-container .mode-icon {
+  font-weight: 700;
+}
+
+.text-diff-container .input-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.text-diff-container .input-panels {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-3);
+  align-items: stretch;
+}
+
+.text-diff-container .input-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-height: 300px;
+}
+
+.text-diff-container .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+}
+
+.text-diff-container .panel-title {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.text-diff-container .file-name {
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.text-diff-container .line-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.text-diff-container .diff-textarea {
+  flex: 1;
+  padding: var(--space-3);
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  resize: none;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.text-diff-container .diff-textarea:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-dim);
+}
+
+.text-diff-container .diff-textarea::placeholder {
+  color: var(--text-disabled);
+}
+
+.text-diff-container .swap-button-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.text-diff-container .swap-btn {
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.text-diff-container .swap-btn:hover {
+  background: var(--bg-overlay);
+  border-color: var(--border-default);
+  color: var(--accent-primary);
+}
+
+.text-diff-container .action-buttons {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.text-diff-container .error-section {
+  background: var(--error-dim);
+  border-color: var(--error);
+}
+
+.text-diff-container .error-message {
+  color: var(--error);
+  margin: 0;
+}
+
+.text-diff-container .stats-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.text-diff-container .stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3);
+}
+
+.text-diff-container .stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+}
+
+.text-diff-container .stat-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-xl);
+  font-weight: 700;
+}
+
+.text-diff-container .stat-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.text-diff-container .stat-item.additions .stat-value {
+  color: var(--success);
+}
+
+.text-diff-container .stat-item.deletions .stat-value {
+  color: var(--error);
+}
+
+.text-diff-container .stat-item.unchanged .stat-value {
+  color: var(--text-secondary);
+}
+
+.text-diff-container .stat-item.total .stat-value {
+  color: var(--accent-primary);
+}
+
+.text-diff-container .result-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.text-diff-container .result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.text-diff-container .copy-btn {
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.text-diff-container .copy-btn:hover {
+  background: var(--bg-overlay);
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+
+.text-diff-container .copy-btn.copied {
+  background: var(--success-dim);
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.text-diff-container .diff-view {
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.text-diff-container .diff-view.side-by-side {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.text-diff-container .diff-panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.text-diff-container .diff-panel.old-panel {
+  border-right: 1px solid var(--border-subtle);
+}
+
+.text-diff-container .diff-panel-header {
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.text-diff-container .diff-lines {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.text-diff-container .diff-line {
+  display: flex;
+  align-items: stretch;
+  min-height: 24px;
+}
+
+.text-diff-container .diff-line.equal {
+  background: transparent;
+}
+
+.text-diff-container .diff-line.delete {
+  background: rgba(255, 82, 82, 0.1);
+}
+
+.text-diff-container .diff-line.insert {
+  background: rgba(0, 230, 118, 0.1);
+}
+
+.text-diff-container .diff-line.empty {
+  background: var(--bg-surface);
+}
+
+.text-diff-container .line-number {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 40px;
+  padding: 0 var(--space-2);
+  color: var(--text-disabled);
+  background: var(--bg-surface);
+  font-size: var(--text-xs);
+  user-select: none;
+}
+
+.text-diff-container .diff-view.unified .line-number,
+.text-diff-container .diff-view.diff-only .line-number {
+  min-width: 35px;
+}
+
+.text-diff-container .line-prefix {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  font-weight: 700;
+  user-select: none;
+}
+
+.text-diff-container .diff-line.delete .line-prefix {
+  color: var(--error);
+}
+
+.text-diff-container .diff-line.insert .line-prefix {
+  color: var(--success);
+}
+
+.text-diff-container .line-content {
+  flex: 1;
+  padding: 0 var(--space-2);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.text-diff-container .no-diff-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+/* Responsive adjustments for diff */
+@media (max-width: 768px) {
+  .text-diff-container .input-panels {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+
+  .text-diff-container .swap-button-container {
+    padding: var(--space-2) 0;
+  }
+
+  .text-diff-container .swap-btn {
+    transform: rotate(90deg);
+  }
+
+  .text-diff-container .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .text-diff-container .diff-view.side-by-side {
+    grid-template-columns: 1fr;
+  }
+
+  .text-diff-container .diff-panel.old-panel {
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .text-diff-container .diff-controls {
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+}
+
 /* ===== Utility Classes ===== */
 .container > h1 {
   font-family: var(--font-display);


### PR DESCRIPTION
## 概要
2つのテキストの差分表示機能を実装しました。

## 変更の種類
- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他

## 関連Issue
Fixes #25

## 変更内容
- 2つのテキストの並列表示（Side by Sideビュー）
- 差分箇所のハイライト（追加は緑、削除は赤）
- 3つの差分モード（Line / Word / Character）
- 3つの表示モード（Side by Side / Unified / Diff Only）
- ファイルのドラッグ&ドロップ対応
- Unified diff形式でのエクスポート（コピーボタン）
- 差分統計の表示（追加/削除/変更なし/合計行数）
- テキスト入れ替えボタン

## テスト
- [x] 手動テスト実施
- [x] ユニットテスト追加/更新（6件追加、全22件パス）
- [x] 既存テストが通ることを確認

## スクリーンショット
N/A（UIは動作確認済み）

## チェックリスト
- [x] コードがプロジェクトのスタイルに従っている
- [x] 自己レビューを実施した
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がないか確認した