### PR TITLE
refactor: iOSスタイルのサイドバーナビゲーションに変更

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,7 +137,205 @@ body {
   padding: var(--space-5);
 }
 
-/* ===== Tab Navigation ===== */
+/* ===== App Layout - iOS Style Sidebar ===== */
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bg-base);
+}
+
+/* Sidebar */
+.sidebar {
+  width: 240px;
+  min-width: 240px;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  transition: all var(--duration-normal) var(--ease-out);
+}
+
+.sidebar.collapsed {
+  width: 64px;
+  min-width: 64px;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+  min-height: 56px;
+}
+
+.sidebar-title {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.sidebar.collapsed .sidebar-title {
+  display: none;
+}
+
+.sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  flex-shrink: 0;
+}
+
+.sidebar-toggle:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.sidebar-toggle:active {
+  transform: scale(0.95);
+}
+
+.sidebar.collapsed .sidebar-toggle {
+  margin: 0 auto;
+}
+
+/* Sidebar Navigation */
+.sidebar-nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3);
+}
+
+.nav-group {
+  margin-bottom: var(--space-4);
+}
+
+.nav-group:last-child {
+  margin-bottom: 0;
+}
+
+.nav-group-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-1);
+}
+
+.nav-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-3) var(--space-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  text-align: left;
+}
+
+.nav-item:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.nav-item:active {
+  transform: scale(0.98);
+  opacity: 0.8;
+}
+
+.nav-item.active {
+  background: var(--accent-primary-dim);
+  color: var(--accent-primary);
+}
+
+.nav-item.active:hover {
+  background: var(--accent-primary-dim);
+}
+
+.nav-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.nav-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.nav-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar.collapsed .nav-item {
+  justify-content: center;
+  padding: var(--space-3);
+}
+
+.sidebar.collapsed .nav-label {
+  display: none;
+}
+
+.sidebar.collapsed .nav-group-label {
+  display: none;
+}
+
+.sidebar.collapsed .nav-group {
+  margin-bottom: var(--space-2);
+}
+
+/* Main Content Area */
+.main-content {
+  flex: 1;
+  overflow: auto;
+  padding: var(--space-5);
+  background: var(--bg-base);
+}
+
+/* Content Panels */
+.content-panel {
+  display: none;
+}
+
+.content-panel.active {
+  display: block;
+  animation: panelIn var(--duration-normal) var(--ease-out);
+}
+
+/* Legacy Tab Navigation (keep for backwards compatibility) */
 .tab-navigation {
   display: flex;
   gap: var(--space-1);
@@ -195,6 +393,26 @@ body {
   display: inline;
 }
 
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 100;
+    transform: translateX(-100%);
+  }
+
+  .sidebar.collapsed {
+    width: 64px;
+    transform: translateX(0);
+  }
+
+  .main-content {
+    margin-left: 64px;
+  }
+}
+
 @media (max-width: 640px) {
   .tab-label {
     display: none;
@@ -207,7 +425,7 @@ body {
   }
 }
 
-/* ===== Tab Panels ===== */
+/* ===== Tab Panels (Legacy) ===== */
 .tab-panel {
   display: none;
 }


### PR DESCRIPTION
## 概要
タブが多すぎる問題を解決するため、iOSスタイルのサイドバーナビゲーションに変更しました。

## 変更の種類
- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] その他

## 関連Issue
Related to #25

## 変更内容
- 横並びタブから縦型サイドバーナビゲーションに変更
- 10個のツールを4つのカテゴリに整理:
  - **Media**: Compress, Edit
  - **Documents**: CSV, PDF, Markdown, Diff
  - **Generators**: UUID, Password, Unit
  - **Productivity**: Kanban
- サイドバー折りたたみ機能を追加
- 各ツールにSVGアイコンを追加
- iOS標準のトランジションアニメーション
- レスポンシブ対応

## テスト
- [x] 手動テスト実施
- [ ] ユニットテスト追加/更新
- [x] 既存テストが通ることを確認

## スクリーンショット
N/A（UIの構造的変更）

## チェックリスト
- [x] コードがプロジェクトのスタイルに従っている
- [x] 自己レビューを実施した
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がないか確認した