### PR TITLE
feat: メモ帳（Scratch Pad）機能を実装

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod kanban;
 mod markdown_to_pdf;
 mod password_generator;
 mod pdf_tools;
+mod scratch_pad;
 mod text_diff;
 mod unit_converter;
 mod uuid_generator;
@@ -33,6 +34,10 @@ use password_generator::{
 use pdf_tools::{
     get_pdf_info, merge_pdfs, split_pdf_by_pages, split_pdf_by_range, PdfInfo, PdfMergeResult,
     PdfSplitResult,
+};
+use scratch_pad::{
+    create_note, delete_note, export_to_file, load_scratch_pad, set_active_note, update_note, Note,
+    ScratchPadData,
 };
 use text_diff::{compute_diff, get_file_info, DiffMode, DiffResult, FileInfo};
 use unit_converter::{
@@ -319,6 +324,40 @@ fn get_text_file_info_cmd(path: String) -> Result<FileInfo, String> {
     get_file_info(&path)
 }
 
+#[tauri::command]
+fn load_scratch_pad_cmd(app: tauri::AppHandle) -> Result<ScratchPadData, String> {
+    load_scratch_pad(&app)
+}
+
+#[tauri::command]
+fn create_note_cmd(app: tauri::AppHandle) -> Result<Note, String> {
+    create_note(&app)
+}
+
+#[tauri::command]
+fn update_note_cmd(
+    app: tauri::AppHandle,
+    note_id: String,
+    content: String,
+) -> Result<Note, String> {
+    update_note(&app, note_id, content)
+}
+
+#[tauri::command]
+fn delete_note_cmd(app: tauri::AppHandle, note_id: String) -> Result<ScratchPadData, String> {
+    delete_note(&app, note_id)
+}
+
+#[tauri::command]
+fn set_active_note_cmd(app: tauri::AppHandle, note_id: String) -> Result<ScratchPadData, String> {
+    set_active_note(&app, note_id)
+}
+
+#[tauri::command]
+fn export_to_file_cmd(content: String, path: String) -> Result<(), String> {
+    export_to_file(content, path)
+}
+
 use tauri::{Emitter, WindowEvent};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -375,7 +414,13 @@ pub fn run() {
             convert_area_cmd,
             convert_volume_cmd,
             compute_diff_cmd,
-            get_text_file_info_cmd
+            get_text_file_info_cmd,
+            load_scratch_pad_cmd,
+            create_note_cmd,
+            update_note_cmd,
+            delete_note_cmd,
+            set_active_note_cmd,
+            export_to_file_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/scratch_pad.rs
+++ b/src-tauri/src/scratch_pad.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Note {
+    pub id: String,
+    pub content: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScratchPadData {
+    pub notes: Vec<Note>,
+    pub active_note_id: Option<String>,
+}
+
+impl Default for ScratchPadData {
+    fn default() -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        let default_note = Note {
+            id: uuid::Uuid::new_v4().to_string(),
+            content: String::new(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        Self {
+            notes: vec![default_note.clone()],
+            active_note_id: Some(default_note.id),
+        }
+    }
+}
+
+fn get_data_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    fs::create_dir_all(&app_data_dir)
+        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
+    Ok(app_data_dir.join("scratch_pad.json"))
+}
+
+pub fn load_scratch_pad(app: &AppHandle) -> Result<ScratchPadData, String> {
+    let path = get_data_path(app)?;
+    if path.exists() {
+        let file_content = fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read scratch pad file: {}", e))?;
+        serde_json::from_str(&file_content)
+            .map_err(|e| format!("Failed to parse scratch pad data: {}", e))
+    } else {
+        Ok(ScratchPadData::default())
+    }
+}
+
+fn save_data(app: &AppHandle, data: &ScratchPadData) -> Result<(), String> {
+    let path = get_data_path(app)?;
+    let json =
+        serde_json::to_string_pretty(data).map_err(|e| format!("Failed to serialize: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write scratch pad file: {}", e))
+}
+
+pub fn create_note(app: &AppHandle) -> Result<Note, String> {
+    let mut data = load_scratch_pad(app)?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let note = Note {
+        id: uuid::Uuid::new_v4().to_string(),
+        content: String::new(),
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    data.notes.insert(0, note.clone());
+    data.active_note_id = Some(note.id.clone());
+    save_data(app, &data)?;
+    Ok(note)
+}
+
+pub fn update_note(app: &AppHandle, note_id: String, content: String) -> Result<Note, String> {
+    let mut data = load_scratch_pad(app)?;
+    let note = data
+        .notes
+        .iter_mut()
+        .find(|n| n.id == note_id)
+        .ok_or_else(|| format!("Note not found: {}", note_id))?;
+
+    note.content = content;
+    note.updated_at = chrono::Utc::now().to_rfc3339();
+    let updated_note = note.clone();
+    save_data(app, &data)?;
+    Ok(updated_note)
+}
+
+pub fn delete_note(app: &AppHandle, note_id: String) -> Result<ScratchPadData, String> {
+    let mut data = load_scratch_pad(app)?;
+    data.notes.retain(|n| n.id != note_id);
+
+    // Update active note
+    if data.active_note_id.as_ref() == Some(&note_id) {
+        data.active_note_id = data.notes.first().map(|n| n.id.clone());
+    }
+
+    // Ensure at least one note exists
+    if data.notes.is_empty() {
+        let now = chrono::Utc::now().to_rfc3339();
+        let default_note = Note {
+            id: uuid::Uuid::new_v4().to_string(),
+            content: String::new(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        data.active_note_id = Some(default_note.id.clone());
+        data.notes.push(default_note);
+    }
+
+    save_data(app, &data)?;
+    Ok(data)
+}
+
+pub fn set_active_note(app: &AppHandle, note_id: String) -> Result<ScratchPadData, String> {
+    let mut data = load_scratch_pad(app)?;
+    if !data.notes.iter().any(|n| n.id == note_id) {
+        return Err(format!("Note not found: {}", note_id));
+    }
+    data.active_note_id = Some(note_id);
+    save_data(app, &data)?;
+    Ok(data)
+}
+
+pub fn export_to_file(content: String, path: String) -> Result<(), String> {
+    fs::write(&path, content).map_err(|e| format!("Failed to write file: {}", e))
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use crate::components::kanban_board::KanbanBoardComponent;
 use crate::components::markdown_to_pdf::MarkdownToPdf;
 use crate::components::password_generator::PasswordGenerator;
 use crate::components::pdf_tools::PdfTools;
+use crate::components::scratch_pad::ScratchPad;
 use crate::components::text_diff::TextDiffComponent;
 use crate::components::unit_converter::UnitConverter;
 use crate::components::uuid_generator::UuidGenerator;
@@ -26,6 +27,7 @@ enum Tab {
     PdfTools,
     MarkdownToPdf,
     KanbanBoard,
+    ScratchPad,
     UuidGenerator,
     PasswordGenerator,
     UnitConverter,
@@ -41,6 +43,7 @@ impl Tab {
             Tab::PdfTools => "PDF",
             Tab::MarkdownToPdf => "Markdown",
             Tab::KanbanBoard => "Kanban",
+            Tab::ScratchPad => "Notes",
             Tab::UuidGenerator => "UUID",
             Tab::PasswordGenerator => "Password",
             Tab::UnitConverter => "Unit",
@@ -56,6 +59,7 @@ impl Tab {
             Tab::PdfTools => "doc.fill",
             Tab::MarkdownToPdf => "doc.text",
             Tab::KanbanBoard => "rectangle.3.group",
+            Tab::ScratchPad => "note.text",
             Tab::UuidGenerator => "key.fill",
             Tab::PasswordGenerator => "lock.fill",
             Tab::UnitConverter => "arrow.left.arrow.right",
@@ -96,7 +100,7 @@ impl Category {
                 Tab::PasswordGenerator,
                 Tab::UnitConverter,
             ],
-            Category::Productivity => vec![Tab::KanbanBoard],
+            Category::Productivity => vec![Tab::KanbanBoard, Tab::ScratchPad],
         }
     }
 }
@@ -422,6 +426,9 @@ pub fn app() -> Html {
                 <div class={if *active_tab == Tab::KanbanBoard { "content-panel active" } else { "content-panel" }}>
                     <KanbanBoardComponent />
                 </div>
+                <div class={if *active_tab == Tab::ScratchPad { "content-panel active" } else { "content-panel" }}>
+                    <ScratchPad />
+                </div>
                 <div class={if *active_tab == Tab::UuidGenerator { "content-panel active" } else { "content-panel" }}>
                     <UuidGenerator />
                 </div>
@@ -512,6 +519,14 @@ fn render_icon(name: &str) -> Html {
                 <circle cx="18" cy="6" r="3"/>
                 <circle cx="6" cy="18" r="3"/>
                 <path d="M18 9a9 9 0 01-9 9"/>
+            </svg>
+        },
+        "note.text" => html! {
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6z"/>
+                <path d="M14 2v6h6"/>
+                <line x1="8" y1="13" x2="16" y2="13"/>
+                <line x1="8" y1="17" x2="13" y2="17"/>
             </svg>
         },
         _ => html! {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -5,6 +5,7 @@ pub mod kanban_board;
 pub mod markdown_to_pdf;
 pub mod password_generator;
 pub mod pdf_tools;
+pub mod scratch_pad;
 pub mod text_diff;
 pub mod unit_converter;
 pub mod uuid_generator;

--- a/src/components/scratch_pad.rs
+++ b/src/components/scratch_pad.rs
@@ -1,0 +1,598 @@
+use gloo_timers::callback::Timeout;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], catch)]
+    async fn invoke(cmd: &str, args: JsValue) -> Result<JsValue, JsValue>;
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "dialog"], catch)]
+    async fn save(options: JsValue) -> Result<JsValue, JsValue>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Note {
+    pub id: String,
+    pub content: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl Note {
+    fn title(&self) -> String {
+        let first_line = self.content.lines().next().unwrap_or("");
+        let title = first_line.trim_start_matches('#').trim();
+        if title.is_empty() {
+            "New Note".to_string()
+        } else if title.len() > 30 {
+            format!("{}...", &title[..27])
+        } else {
+            title.to_string()
+        }
+    }
+
+    fn preview(&self) -> String {
+        let lines: Vec<&str> = self.content.lines().skip(1).take(2).collect();
+        let preview = lines.join(" ").trim().to_string();
+        if preview.len() > 50 {
+            format!("{}...", &preview[..47])
+        } else if preview.is_empty() {
+            "No additional text".to_string()
+        } else {
+            preview
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScratchPadData {
+    pub notes: Vec<Note>,
+    pub active_note_id: Option<String>,
+}
+
+impl Default for ScratchPadData {
+    fn default() -> Self {
+        // Use js_sys for generating UUID-like ID and timestamp in WASM
+        let now = js_sys::Date::new_0()
+            .to_iso_string()
+            .as_string()
+            .unwrap_or_default();
+        let id = format!("{:x}", js_sys::Math::random().to_bits());
+        let default_note = Note {
+            id: id.clone(),
+            content: String::new(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        Self {
+            notes: vec![default_note],
+            active_note_id: Some(id),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownToHtmlResult {
+    pub success: bool,
+    pub html: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct EmptyArgs {}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateNoteArgs {
+    note_id: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteNoteArgs {
+    note_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SetActiveNoteArgs {
+    note_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MarkdownToHtmlArgs {
+    markdown: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExportToFileArgs {
+    content: String,
+    path: String,
+}
+
+#[derive(Serialize)]
+struct SaveDialogOptions {
+    title: String,
+    filters: Vec<SaveFilter>,
+}
+
+#[derive(Serialize)]
+struct SaveFilter {
+    name: String,
+    extensions: Vec<String>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum ViewMode {
+    Edit,
+    Preview,
+    Split,
+}
+
+impl ViewMode {
+    fn label(&self) -> &'static str {
+        match self {
+            ViewMode::Edit => "Edit",
+            ViewMode::Preview => "Preview",
+            ViewMode::Split => "Split",
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct ScratchPadProps {}
+
+#[function_component(ScratchPad)]
+pub fn scratch_pad(_props: &ScratchPadProps) -> Html {
+    let data = use_state(|| Option::<ScratchPadData>::None);
+    let preview_html = use_state(String::new);
+    let is_loading = use_state(|| true);
+    let view_mode = use_state(|| ViewMode::Split);
+    let auto_save_pending = use_state(|| false);
+    let save_status = use_state(|| "");
+
+    // Load data on mount
+    {
+        let data = data.clone();
+        let preview_html = preview_html.clone();
+        let is_loading = is_loading.clone();
+
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&EmptyArgs {}).unwrap();
+
+                let pad_data = match invoke("load_scratch_pad_cmd", args).await {
+                    Ok(result) => serde_wasm_bindgen::from_value::<ScratchPadData>(result)
+                        .unwrap_or_else(|_| ScratchPadData::default()),
+                    Err(_) => ScratchPadData::default(),
+                };
+
+                // Generate initial preview for active note
+                if let Some(active_id) = &pad_data.active_note_id {
+                    if let Some(note) = pad_data.notes.iter().find(|n| &n.id == active_id) {
+                        let md_args = serde_wasm_bindgen::to_value(&MarkdownToHtmlArgs {
+                            markdown: note.content.clone(),
+                        })
+                        .unwrap();
+                        if let Ok(html_result) = invoke("markdown_to_html_cmd", md_args).await {
+                            if let Ok(res) =
+                                serde_wasm_bindgen::from_value::<MarkdownToHtmlResult>(html_result)
+                            {
+                                if let Some(html) = res.html {
+                                    preview_html.set(html);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                data.set(Some(pad_data));
+                is_loading.set(false);
+            });
+            || {}
+        });
+    }
+
+    let active_note = {
+        let data = (*data).clone();
+        data.and_then(|d| {
+            let active_id = d.active_note_id.clone();
+            active_id.and_then(|id| d.notes.into_iter().find(|n| n.id == id))
+        })
+    };
+
+    let on_create_note = {
+        let data = data.clone();
+        let preview_html = preview_html.clone();
+        Callback::from(move |_| {
+            let data = data.clone();
+            let preview_html = preview_html.clone();
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&EmptyArgs {}).unwrap();
+                if let Ok(result) = invoke("create_note_cmd", args).await {
+                    if let Ok(new_note) = serde_wasm_bindgen::from_value::<Note>(result) {
+                        if let Some(d) = (*data).clone() {
+                            let mut new_data = d;
+                            new_data.notes.insert(0, new_note.clone());
+                            new_data.active_note_id = Some(new_note.id);
+                            data.set(Some(new_data));
+                            preview_html.set(String::new());
+                        }
+                    }
+                }
+            });
+        })
+    };
+
+    let on_select_note = {
+        let data = data.clone();
+        let preview_html = preview_html.clone();
+        Callback::from(move |note_id: String| {
+            let data = data.clone();
+            let preview_html = preview_html.clone();
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&SetActiveNoteArgs {
+                    note_id: note_id.clone(),
+                })
+                .unwrap();
+                if let Ok(result) = invoke("set_active_note_cmd", args).await {
+                    if let Ok(pad_data) = serde_wasm_bindgen::from_value::<ScratchPadData>(result) {
+                        // Update preview
+                        if let Some(note) = pad_data.notes.iter().find(|n| n.id == note_id) {
+                            let md_args = serde_wasm_bindgen::to_value(&MarkdownToHtmlArgs {
+                                markdown: note.content.clone(),
+                            })
+                            .unwrap();
+                            if let Ok(html_result) = invoke("markdown_to_html_cmd", md_args).await {
+                                if let Ok(res) = serde_wasm_bindgen::from_value::<
+                                    MarkdownToHtmlResult,
+                                >(html_result)
+                                {
+                                    if let Some(html) = res.html {
+                                        preview_html.set(html);
+                                    }
+                                }
+                            }
+                        }
+                        data.set(Some(pad_data));
+                    }
+                }
+            });
+        })
+    };
+
+    let on_delete_note = {
+        let data = data.clone();
+        let preview_html = preview_html.clone();
+        Callback::from(move |note_id: String| {
+            let data = data.clone();
+            let preview_html = preview_html.clone();
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&DeleteNoteArgs { note_id }).unwrap();
+                if let Ok(result) = invoke("delete_note_cmd", args).await {
+                    if let Ok(pad_data) = serde_wasm_bindgen::from_value::<ScratchPadData>(result) {
+                        // Update preview for new active note
+                        if let Some(active_id) = &pad_data.active_note_id {
+                            if let Some(note) = pad_data.notes.iter().find(|n| &n.id == active_id) {
+                                let md_args = serde_wasm_bindgen::to_value(&MarkdownToHtmlArgs {
+                                    markdown: note.content.clone(),
+                                })
+                                .unwrap();
+                                if let Ok(html_result) =
+                                    invoke("markdown_to_html_cmd", md_args).await
+                                {
+                                    if let Ok(res) =
+                                        serde_wasm_bindgen::from_value::<MarkdownToHtmlResult>(
+                                            html_result,
+                                        )
+                                    {
+                                        if let Some(html) = res.html {
+                                            preview_html.set(html);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        data.set(Some(pad_data));
+                    }
+                }
+            });
+        })
+    };
+
+    let on_content_change = {
+        let data = data.clone();
+        let preview_html = preview_html.clone();
+        let auto_save_pending = auto_save_pending.clone();
+        let save_status = save_status.clone();
+        let active_note = active_note.clone();
+
+        Callback::from(move |e: InputEvent| {
+            let textarea: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            let new_content = textarea.value();
+
+            // Update local state immediately
+            if let Some(note) = active_note.clone() {
+                let data_clone = data.clone();
+                if let Some(d) = (*data_clone).clone() {
+                    let mut new_data = d;
+                    if let Some(n) = new_data.notes.iter_mut().find(|n| n.id == note.id) {
+                        n.content = new_content.clone();
+                    }
+                    data_clone.set(Some(new_data));
+                }
+
+                // Update preview
+                let preview_html_clone = preview_html.clone();
+                let content_for_preview = new_content.clone();
+                spawn_local(async move {
+                    let args = serde_wasm_bindgen::to_value(&MarkdownToHtmlArgs {
+                        markdown: content_for_preview,
+                    })
+                    .unwrap();
+                    if let Ok(result) = invoke("markdown_to_html_cmd", args).await {
+                        if let Ok(res) =
+                            serde_wasm_bindgen::from_value::<MarkdownToHtmlResult>(result)
+                        {
+                            if let Some(html) = res.html {
+                                preview_html_clone.set(html);
+                            }
+                        }
+                    }
+                });
+
+                // Debounced auto-save
+                if !*auto_save_pending {
+                    auto_save_pending.set(true);
+                    save_status.set("Saving...");
+
+                    let save_status_clone = save_status.clone();
+                    let auto_save_pending_clone = auto_save_pending.clone();
+                    let content_for_save = new_content;
+                    let note_id = note.id.clone();
+
+                    Timeout::new(1000, move || {
+                        let save_status_after = save_status_clone.clone();
+                        let pending_after = auto_save_pending_clone.clone();
+
+                        spawn_local(async move {
+                            let args = serde_wasm_bindgen::to_value(&UpdateNoteArgs {
+                                note_id,
+                                content: content_for_save,
+                            })
+                            .unwrap();
+                            match invoke("update_note_cmd", args).await {
+                                Ok(result) => {
+                                    if serde_wasm_bindgen::from_value::<Note>(result).is_ok() {
+                                        save_status_after.set("Saved");
+                                    } else {
+                                        save_status_after.set("Save failed");
+                                    }
+                                }
+                                Err(_) => {
+                                    save_status_after.set("Save failed");
+                                }
+                            }
+
+                            let status_reset = save_status_after.clone();
+                            Timeout::new(2000, move || {
+                                status_reset.set("");
+                            })
+                            .forget();
+
+                            pending_after.set(false);
+                        });
+                    })
+                    .forget();
+                }
+            }
+        })
+    };
+
+    let on_view_mode_change = {
+        let view_mode = view_mode.clone();
+        Callback::from(move |mode: ViewMode| {
+            view_mode.set(mode);
+        })
+    };
+
+    let on_save_file = {
+        let active_note = active_note.clone();
+        let save_status = save_status.clone();
+        Callback::from(move |_| {
+            if let Some(note) = active_note.clone() {
+                let content = note.content.clone();
+                let save_status = save_status.clone();
+                spawn_local(async move {
+                    let options = serde_wasm_bindgen::to_value(&SaveDialogOptions {
+                        title: "Save Markdown File".to_string(),
+                        filters: vec![SaveFilter {
+                            name: "Markdown".to_string(),
+                            extensions: vec!["md".to_string()],
+                        }],
+                    })
+                    .unwrap();
+
+                    if let Ok(path_result) = save(options).await {
+                        if let Some(path) = path_result.as_string() {
+                            let args =
+                                serde_wasm_bindgen::to_value(&ExportToFileArgs { content, path })
+                                    .unwrap();
+                            let _ = invoke("export_to_file_cmd", args).await;
+                            save_status.set("Exported!");
+                            let status_reset = save_status.clone();
+                            Timeout::new(2000, move || {
+                                status_reset.set("");
+                            })
+                            .forget();
+                        }
+                    }
+                });
+            }
+        })
+    };
+
+    if *is_loading {
+        return html! {
+            <div class="container container-wide">
+                <div class="section">
+                    <div class="scratch-pad-loading">
+                        <div class="processing-spinner"></div>
+                        <p>{"Loading..."}</p>
+                    </div>
+                </div>
+            </div>
+        };
+    }
+
+    let notes = (*data).clone().map(|d| d.notes).unwrap_or_default();
+    let view_modes = [ViewMode::Edit, ViewMode::Split, ViewMode::Preview];
+
+    html! {
+        <div class="container container-wide">
+            <div class="notes-app">
+                // Sidebar
+                <div class="notes-sidebar">
+                    <div class="notes-sidebar-header">
+                        <span class="notes-count">{format!("{} Notes", notes.len())}</span>
+                        <button class="new-note-btn" onclick={on_create_note} title="New Note">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <line x1="12" y1="5" x2="12" y2="19"/>
+                                <line x1="5" y1="12" x2="19" y2="12"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="notes-list">
+                        { for notes.iter().map(|note| {
+                            let is_active = active_note.as_ref().map(|n| n.id == note.id).unwrap_or(false);
+                            let on_select = on_select_note.clone();
+                            let on_delete = on_delete_note.clone();
+                            let id_for_select = note.id.clone();
+                            let id_for_delete = note.id.clone();
+                            html! {
+                                <div
+                                    class={classes!("note-item", is_active.then_some("active"))}
+                                    onclick={Callback::from(move |_| on_select.emit(id_for_select.clone()))}
+                                >
+                                    <div class="note-item-content">
+                                        <div class="note-item-title">{note.title()}</div>
+                                        <div class="note-item-preview">{note.preview()}</div>
+                                    </div>
+                                    if notes.len() > 1 {
+                                        <button
+                                            class="note-delete-btn"
+                                            onclick={Callback::from(move |e: MouseEvent| {
+                                                e.stop_propagation();
+                                                on_delete.emit(id_for_delete.clone());
+                                            })}
+                                            title="Delete"
+                                        >
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <line x1="18" y1="6" x2="6" y2="18"/>
+                                                <line x1="6" y1="6" x2="18" y2="18"/>
+                                            </svg>
+                                        </button>
+                                    }
+                                </div>
+                            }
+                        })}
+                    </div>
+                </div>
+
+                // Editor
+                <div class="notes-editor">
+                    if let Some(note) = active_note.clone() {
+                        <div class="notes-editor-header">
+                            <div class="notes-editor-status">
+                                if !(*save_status).is_empty() {
+                                    <span class="save-status">{*save_status}</span>
+                                }
+                            </div>
+                            <div class="notes-editor-actions">
+                                <button class="export-btn" onclick={on_save_file} title="Export as file">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                                        <polyline points="7 10 12 15 17 10"/>
+                                        <line x1="12" y1="15" x2="12" y2="3"/>
+                                    </svg>
+                                </button>
+                                <div class="view-mode-tabs">
+                                    { for view_modes.iter().map(|mode| {
+                                        let is_active = *view_mode == *mode;
+                                        let on_click = on_view_mode_change.clone();
+                                        let m = *mode;
+                                        html! {
+                                            <button
+                                                class={classes!("view-mode-tab", is_active.then_some("active"))}
+                                                onclick={Callback::from(move |_| on_click.emit(m))}
+                                            >
+                                                {mode.label()}
+                                            </button>
+                                        }
+                                    })}
+                                </div>
+                            </div>
+                        </div>
+                        <div class={classes!(
+                            "notes-editor-content",
+                            match *view_mode {
+                                ViewMode::Edit => "edit-only",
+                                ViewMode::Preview => "preview-only",
+                                ViewMode::Split => "split-view",
+                            }
+                        )}>
+                            if *view_mode != ViewMode::Preview {
+                                <div class="editor-pane">
+                                    <textarea
+                                        class="markdown-editor"
+                                        value={note.content.clone()}
+                                        oninput={on_content_change}
+                                        placeholder="# Start writing...
+
+Write your notes in Markdown format.
+
+**Bold**, *italic*, `code`
+
+- List items
+- More items
+
+> Quotes"
+                                        spellcheck="false"
+                                    />
+                                </div>
+                            }
+                            if *view_mode != ViewMode::Edit {
+                                <div class="preview-pane">
+                                    <div class="markdown-preview">
+                                        { Html::from_html_unchecked(AttrValue::from((*preview_html).clone())) }
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                        <div class="notes-editor-footer">
+                            <span class="char-count">
+                                {format!("{} characters", note.content.len())}
+                            </span>
+                            <span class="line-count">
+                                {format!("{} lines", note.content.lines().count().max(1))}
+                            </span>
+                        </div>
+                    } else {
+                        <div class="no-note-selected">
+                            <p>{"Select a note or create a new one"}</p>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -3283,6 +3283,509 @@ body {
   }
 }
 
+/* ===== Notes App (macOS Style) ===== */
+.notes-app {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  height: calc(100vh - var(--space-10) - var(--space-10));
+  min-height: 500px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+/* Sidebar */
+.notes-sidebar {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-subtle);
+}
+
+.notes-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.notes-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.new-note-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--accent-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--bg-base);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.new-note-btn:hover {
+  box-shadow: 0 0 12px var(--accent-primary-glow);
+  transform: scale(1.05);
+}
+
+.new-note-btn:active {
+  transform: scale(0.95);
+}
+
+.notes-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-2);
+}
+
+.note-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  margin-bottom: 2px;
+}
+
+.note-item:hover {
+  background: var(--bg-overlay);
+}
+
+.note-item.active {
+  background: var(--accent-primary-dim);
+}
+
+.note-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.note-item-title {
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2px;
+}
+
+.note-item.active .note-item-title {
+  color: var(--accent-primary);
+}
+
+.note-item-preview {
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.note-delete-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  opacity: 0;
+  transition: all var(--duration-fast) var(--ease-out);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.note-item:hover .note-delete-btn {
+  opacity: 1;
+}
+
+.note-delete-btn:hover {
+  background: var(--error-dim);
+  color: var(--error);
+}
+
+/* Editor */
+.notes-editor {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  min-height: 0;
+}
+
+.notes-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  min-height: 44px;
+}
+
+.notes-editor-status {
+  display: flex;
+  align-items: center;
+}
+
+.save-status {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  padding: var(--space-1) var(--space-2);
+  background: var(--bg-base);
+  border-radius: var(--radius-sm);
+}
+
+.notes-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.export-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.export-btn:hover {
+  background: var(--bg-overlay);
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+
+.export-btn:active {
+  transform: scale(0.95);
+}
+
+.view-mode-tabs {
+  display: flex;
+  gap: var(--space-1);
+  background: var(--bg-base);
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+}
+
+.view-mode-tab {
+  padding: var(--space-2) var(--space-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.view-mode-tab:hover {
+  color: var(--text-primary);
+}
+
+.view-mode-tab.active {
+  background: var(--accent-primary);
+  color: var(--bg-base);
+}
+
+.notes-editor-content {
+  flex: 1;
+  display: grid;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.notes-editor-content.edit-only {
+  grid-template-columns: 1fr;
+}
+
+.notes-editor-content.preview-only {
+  grid-template-columns: 1fr;
+}
+
+.notes-editor-content.split-view {
+  grid-template-columns: 1fr 1fr;
+}
+
+.editor-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.notes-editor-content.edit-only .editor-pane {
+  border-right: none;
+}
+
+.markdown-editor {
+  flex: 1;
+  width: 100%;
+  padding: var(--space-4);
+  background: var(--bg-base);
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  resize: none;
+  tab-size: 2;
+}
+
+.markdown-editor:focus {
+  outline: none;
+}
+
+.markdown-editor::placeholder {
+  color: var(--text-tertiary);
+}
+
+.preview-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  background: var(--bg-base);
+}
+
+.markdown-preview {
+  flex: 1;
+  padding: var(--space-4);
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+/* Markdown Preview Styles */
+.markdown-preview h1,
+.markdown-preview h2,
+.markdown-preview h3,
+.markdown-preview h4,
+.markdown-preview h5,
+.markdown-preview h6 {
+  margin-top: var(--space-6);
+  margin-bottom: var(--space-3);
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+
+.markdown-preview h1 {
+  font-size: var(--text-2xl);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.markdown-preview h2 {
+  font-size: var(--text-xl);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.markdown-preview h3 {
+  font-size: var(--text-lg);
+}
+
+.markdown-preview p {
+  margin: 0 0 var(--space-4) 0;
+}
+
+.markdown-preview a {
+  color: var(--accent-primary);
+  text-decoration: none;
+}
+
+.markdown-preview a:hover {
+  text-decoration: underline;
+}
+
+.markdown-preview strong {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.markdown-preview em {
+  font-style: italic;
+}
+
+.markdown-preview code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  padding: 2px 6px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  color: var(--accent-secondary);
+}
+
+.markdown-preview pre {
+  margin: 0 0 var(--space-4) 0;
+  padding: var(--space-4);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+}
+
+.markdown-preview pre code {
+  padding: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.markdown-preview blockquote {
+  margin: 0 0 var(--space-4) 0;
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--accent-primary);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+
+.markdown-preview blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-preview ul,
+.markdown-preview ol {
+  margin: 0 0 var(--space-4) 0;
+  padding-left: var(--space-6);
+}
+
+.markdown-preview li {
+  margin-bottom: var(--space-2);
+}
+
+.markdown-preview li:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-preview hr {
+  margin: var(--space-6) 0;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.markdown-preview table {
+  width: 100%;
+  margin: 0 0 var(--space-4) 0;
+  border-collapse: collapse;
+}
+
+.markdown-preview th,
+.markdown-preview td {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  text-align: left;
+}
+
+.markdown-preview th {
+  background: var(--bg-elevated);
+  font-weight: 600;
+}
+
+.markdown-preview img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
+.notes-editor-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+}
+
+.char-count,
+.line-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.no-note-selected {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+}
+
+.no-note-selected p {
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  margin: 0;
+}
+
+/* Loading State */
+.scratch-pad-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-10);
+}
+
+.scratch-pad-loading p {
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .notes-app {
+    grid-template-columns: 1fr;
+    grid-template-rows: 180px 1fr;
+  }
+
+  .notes-sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .notes-editor-content.split-view {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  .editor-pane {
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+}
+
 /* ===== Utility Classes ===== */
 .container > h1 {
   font-family: var(--font-display);


### PR DESCRIPTION
## 概要
macOS Notes.appスタイルのメモ帳機能を実装しました。

## 変更の種類
- [x] 新機能

## 関連Issue
Fixes #26

## 変更内容
- サイドバー付きノート一覧（タイトル自動生成、プレビュー表示）
- マークダウンエディタ（Edit/Split/Preview モード切り替え）
- 自動保存（1秒デバウンス）
- 複数ノート管理（追加・削除・切り替え）
- ファイルエクスポート（.md形式）
- アプリデータディレクトリにJSON形式で永続化

### 追加ファイル
- `src-tauri/src/scratch_pad.rs` - バックエンドモジュール
- `src/components/scratch_pad.rs` - フロントエンドコンポーネント

### 変更ファイル
- `src-tauri/src/lib.rs` - Tauriコマンド登録
- `src/app.rs` - タブ追加
- `src/components/mod.rs` - モジュール登録
- `styles.css` - macOS Notes風スタイル追加

## テスト
- [x] 手動テスト実施
  - ノートの作成・削除
  - テキスト編集と自動保存
  - ビューモード切り替え（Edit/Split/Preview）
  - マークダウンプレビュー
  - ファイルエクスポート
- [x] 既存テストが通ることを確認

## チェックリスト
- [x] コードがプロジェクトのスタイルに従っている
- [x] 自己レビューを実施した
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がないか確認した