### PR TITLE
feat: クリップボード履歴機能を追加 (#20)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,4 +36,5 @@ regex = "1"
 rand = "0.8"
 similar = "2"
 base64 = "0.22"
+arboard = "3"
 

--- a/src-tauri/src/clipboard_history.rs
+++ b/src-tauri/src/clipboard_history.rs
@@ -1,0 +1,307 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipboardEntry {
+    pub id: String,
+    pub content: String,
+    pub content_type: ContentType,
+    pub pinned: bool,
+    pub created_at: String,
+    pub copied_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ContentType {
+    Text,
+    Code,
+    Url,
+    Email,
+    Password,
+}
+
+impl ContentType {
+    fn detect(content: &str) -> Self {
+        let trimmed = content.trim();
+
+        // URL detection
+        if trimmed.starts_with("http://")
+            || trimmed.starts_with("https://")
+            || trimmed.starts_with("ftp://")
+        {
+            return ContentType::Url;
+        }
+
+        // Email detection
+        if trimmed.contains('@')
+            && trimmed.contains('.')
+            && !trimmed.contains(' ')
+            && trimmed.len() < 254
+        {
+            let at_pos = trimmed.find('@').unwrap();
+            let before_at = &trimmed[..at_pos];
+            let after_at = &trimmed[at_pos + 1..];
+            if !before_at.is_empty() && after_at.contains('.') && !after_at.starts_with('.') {
+                return ContentType::Email;
+            }
+        }
+
+        // Code detection (simple heuristics)
+        let code_indicators = [
+            "fn ",
+            "let ",
+            "const ",
+            "var ",
+            "function ",
+            "class ",
+            "import ",
+            "export ",
+            "def ",
+            "if ",
+            "for ",
+            "while ",
+            "return ",
+            "pub ",
+            "async ",
+            "await ",
+            "=>",
+            "->",
+            "::",
+            "{{",
+            "}}",
+            "();",
+            ");",
+            "](",
+            "/*",
+            "*/",
+            "//",
+        ];
+        let has_code_indicator = code_indicators.iter().any(|&ind| trimmed.contains(ind));
+        let has_brackets = trimmed.contains('{') && trimmed.contains('}');
+        let has_semicolons = trimmed.matches(';').count() > 1;
+
+        if has_code_indicator || (has_brackets && has_semicolons) {
+            return ContentType::Code;
+        }
+
+        // Password detection (high entropy, no spaces, mixed chars)
+        if !trimmed.contains(' ')
+            && trimmed.len() >= 8
+            && trimmed.len() <= 128
+            && trimmed.chars().any(|c| c.is_ascii_digit())
+            && trimmed.chars().any(|c| c.is_ascii_lowercase())
+            && (trimmed.chars().any(|c| c.is_ascii_uppercase())
+                || trimmed.chars().any(|c| !c.is_alphanumeric()))
+        {
+            return ContentType::Password;
+        }
+
+        ContentType::Text
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipboardSettings {
+    pub max_entries: u32,
+    pub exclude_passwords: bool,
+    pub exclude_patterns: Vec<String>,
+}
+
+impl Default for ClipboardSettings {
+    fn default() -> Self {
+        Self {
+            max_entries: 100,
+            exclude_passwords: true,
+            exclude_patterns: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ClipboardHistoryData {
+    pub entries: Vec<ClipboardEntry>,
+    pub settings: ClipboardSettings,
+}
+
+fn get_data_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    fs::create_dir_all(&app_data_dir)
+        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
+    Ok(app_data_dir.join("clipboard_history.json"))
+}
+
+pub fn load_clipboard_history(app: &AppHandle) -> Result<ClipboardHistoryData, String> {
+    let path = get_data_path(app)?;
+    if path.exists() {
+        let file_content = fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read clipboard history file: {}", e))?;
+        serde_json::from_str(&file_content)
+            .map_err(|e| format!("Failed to parse clipboard history data: {}", e))
+    } else {
+        Ok(ClipboardHistoryData::default())
+    }
+}
+
+fn save_data(app: &AppHandle, data: &ClipboardHistoryData) -> Result<(), String> {
+    let path = get_data_path(app)?;
+    let json =
+        serde_json::to_string_pretty(data).map_err(|e| format!("Failed to serialize: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write clipboard history file: {}", e))
+}
+
+pub fn add_clipboard_entry(app: &AppHandle, content: String) -> Result<ClipboardEntry, String> {
+    let mut data = load_clipboard_history(app)?;
+
+    // Detect content type
+    let content_type = ContentType::detect(&content);
+
+    // Check if password should be excluded
+    if data.settings.exclude_passwords && content_type == ContentType::Password {
+        return Err("Password-like content is excluded by settings".to_string());
+    }
+
+    // Check exclude patterns
+    for pattern in &data.settings.exclude_patterns {
+        if content.contains(pattern) {
+            return Err(format!("Content matches exclude pattern: {}", pattern));
+        }
+    }
+
+    // Check if entry already exists (deduplication)
+    if let Some(existing) = data.entries.iter_mut().find(|e| e.content == content) {
+        existing.copied_count += 1;
+        existing.created_at = chrono::Utc::now().to_rfc3339();
+        let entry = existing.clone();
+
+        // Move to top (most recent)
+        let content_clone = content.clone();
+        data.entries.retain(|e| e.content != content_clone);
+        data.entries.insert(0, entry.clone());
+
+        save_data(app, &data)?;
+        return Ok(entry);
+    }
+
+    // Create new entry
+    let entry = ClipboardEntry {
+        id: uuid::Uuid::new_v4().to_string(),
+        content,
+        content_type,
+        pinned: false,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        copied_count: 1,
+    };
+
+    // Add to beginning of list
+    data.entries.insert(0, entry.clone());
+
+    // Trim to max entries (keeping pinned items)
+    let max = data.settings.max_entries as usize;
+    if data.entries.len() > max {
+        // Separate pinned and unpinned
+        let (pinned, mut unpinned): (Vec<_>, Vec<_>) =
+            data.entries.into_iter().partition(|e| e.pinned);
+
+        // Keep pinned + as many unpinned as possible
+        let remaining_slots = max.saturating_sub(pinned.len());
+        unpinned.truncate(remaining_slots);
+
+        // Merge back
+        data.entries = pinned;
+        data.entries.extend(unpinned);
+
+        // Sort by created_at (most recent first)
+        data.entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    }
+
+    save_data(app, &data)?;
+    Ok(entry)
+}
+
+pub fn delete_clipboard_entry(
+    app: &AppHandle,
+    entry_id: String,
+) -> Result<ClipboardHistoryData, String> {
+    let mut data = load_clipboard_history(app)?;
+    data.entries.retain(|e| e.id != entry_id);
+    save_data(app, &data)?;
+    Ok(data)
+}
+
+pub fn clear_clipboard_history(app: &AppHandle) -> Result<ClipboardHistoryData, String> {
+    let mut data = load_clipboard_history(app)?;
+    // Keep only pinned items
+    data.entries.retain(|e| e.pinned);
+    save_data(app, &data)?;
+    Ok(data)
+}
+
+pub fn toggle_pinned(app: &AppHandle, entry_id: String) -> Result<ClipboardEntry, String> {
+    let mut data = load_clipboard_history(app)?;
+    let entry = data
+        .entries
+        .iter_mut()
+        .find(|e| e.id == entry_id)
+        .ok_or_else(|| format!("Entry not found: {}", entry_id))?;
+
+    entry.pinned = !entry.pinned;
+    let updated_entry = entry.clone();
+    save_data(app, &data)?;
+    Ok(updated_entry)
+}
+
+pub fn search_clipboard_history(
+    app: &AppHandle,
+    query: String,
+) -> Result<Vec<ClipboardEntry>, String> {
+    let data = load_clipboard_history(app)?;
+    let query_lower = query.to_lowercase();
+
+    let results: Vec<ClipboardEntry> = data
+        .entries
+        .into_iter()
+        .filter(|e| e.content.to_lowercase().contains(&query_lower))
+        .collect();
+
+    Ok(results)
+}
+
+pub fn update_clipboard_settings(
+    app: &AppHandle,
+    settings: ClipboardSettings,
+) -> Result<ClipboardHistoryData, String> {
+    let mut data = load_clipboard_history(app)?;
+    data.settings = settings;
+    save_data(app, &data)?;
+    Ok(data)
+}
+
+pub fn copy_entry_to_clipboard(
+    app: &AppHandle,
+    entry_id: String,
+) -> Result<ClipboardEntry, String> {
+    let mut data = load_clipboard_history(app)?;
+    let entry = data
+        .entries
+        .iter_mut()
+        .find(|e| e.id == entry_id)
+        .ok_or_else(|| format!("Entry not found: {}", entry_id))?;
+
+    entry.copied_count += 1;
+    entry.created_at = chrono::Utc::now().to_rfc3339();
+    let updated_entry = entry.clone();
+
+    // Move to top
+    let entry_id_clone = entry_id.clone();
+    let entry_clone = updated_entry.clone();
+    data.entries.retain(|e| e.id != entry_id_clone);
+    data.entries.insert(0, entry_clone);
+
+    save_data(app, &data)?;
+    Ok(updated_entry)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod base64_encoder;
+mod clipboard_history;
 mod csv_viewer;
 mod image_compressor;
 mod image_editor;
@@ -17,6 +18,11 @@ mod uuid_generator;
 use base64_encoder::{
     decode_base64, decode_base64_image, encode_base64, encode_image_to_base64,
     Base64DecodeImageResult, Base64DecodeResult, Base64EncodeResult, Base64ImageResult,
+};
+use clipboard_history::{
+    add_clipboard_entry, clear_clipboard_history, copy_entry_to_clipboard, delete_clipboard_entry,
+    load_clipboard_history, search_clipboard_history, toggle_pinned, update_clipboard_settings,
+    ClipboardEntry, ClipboardHistoryData, ClipboardSettings,
 };
 use csv_viewer::{get_csv_info, read_csv, save_csv, CsvData, CsvInfo};
 use image_compressor::{
@@ -459,13 +465,99 @@ fn get_current_unix_time_cmd() -> CurrentUnixTimeResult {
     get_current_unix_time()
 }
 
+#[tauri::command]
+fn load_clipboard_history_cmd(app: tauri::AppHandle) -> Result<ClipboardHistoryData, String> {
+    load_clipboard_history(&app)
+}
+
+#[tauri::command]
+fn add_clipboard_entry_cmd(
+    app: tauri::AppHandle,
+    content: String,
+) -> Result<ClipboardEntry, String> {
+    add_clipboard_entry(&app, content)
+}
+
+#[tauri::command]
+fn delete_clipboard_entry_cmd(
+    app: tauri::AppHandle,
+    entry_id: String,
+) -> Result<ClipboardHistoryData, String> {
+    delete_clipboard_entry(&app, entry_id)
+}
+
+#[tauri::command]
+fn clear_clipboard_history_cmd(app: tauri::AppHandle) -> Result<ClipboardHistoryData, String> {
+    clear_clipboard_history(&app)
+}
+
+#[tauri::command]
+fn toggle_clipboard_pinned_cmd(
+    app: tauri::AppHandle,
+    entry_id: String,
+) -> Result<ClipboardEntry, String> {
+    toggle_pinned(&app, entry_id)
+}
+
+#[tauri::command]
+fn search_clipboard_history_cmd(
+    app: tauri::AppHandle,
+    query: String,
+) -> Result<Vec<ClipboardEntry>, String> {
+    search_clipboard_history(&app, query)
+}
+
+#[tauri::command]
+fn update_clipboard_settings_cmd(
+    app: tauri::AppHandle,
+    settings: ClipboardSettings,
+) -> Result<ClipboardHistoryData, String> {
+    update_clipboard_settings(&app, settings)
+}
+
+#[tauri::command]
+fn copy_clipboard_entry_cmd(
+    app: tauri::AppHandle,
+    entry_id: String,
+) -> Result<ClipboardEntry, String> {
+    copy_entry_to_clipboard(&app, entry_id)
+}
+
 use tauri::{Emitter, WindowEvent};
+
+fn start_clipboard_monitor(app_handle: tauri::AppHandle) {
+    std::thread::spawn(move || {
+        let mut clipboard = match arboard::Clipboard::new() {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        // Initialize with current clipboard content to avoid adding existing content on startup
+        let mut last_content = clipboard.get_text().unwrap_or_default();
+
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(1000));
+            if let Ok(content) = clipboard.get_text() {
+                if content != last_content && !content.trim().is_empty() {
+                    last_content = content.clone();
+                    if add_clipboard_entry(&app_handle, content).is_ok() {
+                        let _ = app_handle.emit("clipboard-changed", ());
+                    }
+                }
+            }
+        }
+    });
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .setup(|app| {
+            start_clipboard_monitor(app.handle().clone());
+            Ok(())
+        })
         .on_window_event(|window, event| {
             if let WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) = event {
                 let paths_str: Vec<String> = paths
@@ -535,7 +627,15 @@ pub fn run() {
             decode_base64_image_cmd,
             unix_to_datetime_cmd,
             datetime_to_unix_cmd,
-            get_current_unix_time_cmd
+            get_current_unix_time_cmd,
+            load_clipboard_history_cmd,
+            add_clipboard_entry_cmd,
+            delete_clipboard_entry_cmd,
+            clear_clipboard_history_cmd,
+            toggle_clipboard_pinned_cmd,
+            search_clipboard_history_cmd,
+            update_clipboard_settings_cmd,
+            copy_clipboard_entry_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/unix_time_converter.rs
+++ b/src-tauri/src/unix_time_converter.rs
@@ -264,7 +264,11 @@ mod tests {
     fn test_datetime_to_unix_date_only() {
         let result = datetime_to_unix("2026-02-08", TimezoneOption::Utc);
         println!("Result: {:?}", result);
-        assert!(result.success, "Expected success but got error: {:?}", result.error);
+        assert!(
+            result.success,
+            "Expected success but got error: {:?}",
+            result.error
+        );
         assert!(result.unix_seconds > 0);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::components::base64_encoder::Base64Encoder;
+use crate::components::clipboard_history::ClipboardHistory;
 use crate::components::csv_viewer::CsvViewer;
 use crate::components::image_compressor::ImageCompressor;
 use crate::components::image_editor::ImageEditor;
@@ -36,6 +37,7 @@ enum Tab {
     MarkdownToPdf,
     KanbanBoard,
     ScratchPad,
+    ClipboardHistory,
     UuidGenerator,
     PasswordGenerator,
     UnitConverter,
@@ -56,6 +58,7 @@ impl Tab {
             Tab::MarkdownToPdf => "app.tabs.markdown",
             Tab::KanbanBoard => "app.tabs.kanban",
             Tab::ScratchPad => "app.tabs.notes",
+            Tab::ClipboardHistory => "app.tabs.clipboard",
             Tab::UuidGenerator => "app.tabs.uuid",
             Tab::PasswordGenerator => "app.tabs.password",
             Tab::UnitConverter => "app.tabs.unit",
@@ -76,6 +79,7 @@ impl Tab {
             Tab::MarkdownToPdf => "doc.text",
             Tab::KanbanBoard => "rectangle.3.group",
             Tab::ScratchPad => "note.text",
+            Tab::ClipboardHistory => "clipboard",
             Tab::UuidGenerator => "key.fill",
             Tab::PasswordGenerator => "lock.fill",
             Tab::UnitConverter => "arrow.left.arrow.right",
@@ -124,7 +128,9 @@ impl Category {
                 Tab::RegexTester,
                 Tab::Base64Encoder,
             ],
-            Category::Productivity => vec![Tab::KanbanBoard, Tab::ScratchPad],
+            Category::Productivity => {
+                vec![Tab::KanbanBoard, Tab::ScratchPad, Tab::ClipboardHistory]
+            }
         }
     }
 }
@@ -506,6 +512,9 @@ fn app_inner() -> Html {
                 <div class={if *active_tab == Tab::ScratchPad { "content-panel active" } else { "content-panel" }}>
                     <ScratchPad />
                 </div>
+                <div class={if *active_tab == Tab::ClipboardHistory { "content-panel active" } else { "content-panel" }}>
+                    <ClipboardHistory />
+                </div>
                 <div class={if *active_tab == Tab::UuidGenerator { "content-panel active" } else { "content-panel" }}>
                     <UuidGenerator />
                 </div>
@@ -628,6 +637,12 @@ fn render_icon(name: &str) -> Html {
                 <path d="M14 2v6h6"/>
                 <line x1="8" y1="13" x2="16" y2="13"/>
                 <line x1="8" y1="17" x2="13" y2="17"/>
+            </svg>
+        },
+        "clipboard" => html! {
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path d="M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2"/>
+                <rect x="8" y="2" width="8" height="4" rx="1"/>
             </svg>
         },
         "asterisk.circle" => html! {

--- a/src/components/clipboard_history.rs
+++ b/src/components/clipboard_history.rs
@@ -1,0 +1,721 @@
+use i18nrs::yew::use_translation;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], catch)]
+    async fn invoke(cmd: &str, args: JsValue) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "event"], js_name = listen)]
+    async fn tauri_listen(event: &str, handler: &Closure<dyn Fn(JsValue)>) -> JsValue;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ContentType {
+    Text,
+    Code,
+    Url,
+    Email,
+    Password,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ClipboardEntry {
+    pub id: String,
+    pub content: String,
+    pub content_type: ContentType,
+    pub pinned: bool,
+    pub created_at: String,
+    pub copied_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipboardSettings {
+    pub max_entries: u32,
+    pub exclude_passwords: bool,
+    pub exclude_patterns: Vec<String>,
+}
+
+impl Default for ClipboardSettings {
+    fn default() -> Self {
+        Self {
+            max_entries: 100,
+            exclude_passwords: true,
+            exclude_patterns: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipboardHistoryData {
+    pub entries: Vec<ClipboardEntry>,
+    pub settings: ClipboardSettings,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EntryIdArgs {
+    entry_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SearchArgs {
+    query: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AddEntryArgs {
+    content: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateSettingsArgs {
+    settings: ClipboardSettings,
+}
+
+#[function_component(ClipboardHistory)]
+pub fn clipboard_history() -> Html {
+    let (i18n, _) = use_translation();
+    let entries = use_state(Vec::<ClipboardEntry>::new);
+    let settings = use_state(ClipboardSettings::default);
+    let search_query = use_state(String::new);
+    let is_loading = use_state(|| true);
+    let show_settings = use_state(|| false);
+    let copied_id = use_state(|| Option::<String>::None);
+    let new_entry_content = use_state(String::new);
+
+    // Load data on mount
+    {
+        let entries = entries.clone();
+        let settings = settings.clone();
+        let is_loading = is_loading.clone();
+
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                if let Ok(result) = invoke("load_clipboard_history_cmd", JsValue::null()).await {
+                    if let Ok(data) =
+                        serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                    {
+                        entries.set(data.entries);
+                        settings.set(data.settings);
+                    }
+                }
+                is_loading.set(false);
+            });
+            || {}
+        });
+    }
+
+    // Listen for clipboard changes from backend monitor
+    {
+        let entries = entries.clone();
+        let settings = settings.clone();
+
+        use_effect_with((), move |_| {
+            let entries = entries.clone();
+            let settings = settings.clone();
+
+            spawn_local(async move {
+                let handler = {
+                    let entries = entries.clone();
+                    let settings = settings.clone();
+                    Closure::new(move |_event: JsValue| {
+                        let entries = entries.clone();
+                        let settings = settings.clone();
+                        spawn_local(async move {
+                            if let Ok(result) =
+                                invoke("load_clipboard_history_cmd", JsValue::null()).await
+                            {
+                                if let Ok(data) =
+                                    serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                                {
+                                    entries.set(data.entries);
+                                    settings.set(data.settings);
+                                }
+                            }
+                        });
+                    })
+                };
+                let _ = tauri_listen("clipboard-changed", &handler).await;
+                handler.forget();
+            });
+
+            || {}
+        });
+    }
+
+    let on_search = {
+        let search_query = search_query.clone();
+        let entries = entries.clone();
+
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let query = input.value();
+            search_query.set(query.clone());
+
+            if query.is_empty() {
+                let entries = entries.clone();
+                spawn_local(async move {
+                    if let Ok(result) =
+                        invoke("load_clipboard_history_cmd", JsValue::null()).await
+                    {
+                        if let Ok(data) =
+                            serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                        {
+                            entries.set(data.entries);
+                        }
+                    }
+                });
+            } else {
+                let entries = entries.clone();
+                spawn_local(async move {
+                    let args = SearchArgs { query };
+                    if let Ok(args_js) = serde_wasm_bindgen::to_value(&args) {
+                        if let Ok(result) =
+                            invoke("search_clipboard_history_cmd", args_js).await
+                        {
+                            if let Ok(results) =
+                                serde_wasm_bindgen::from_value::<Vec<ClipboardEntry>>(result)
+                            {
+                                entries.set(results);
+                            }
+                        }
+                    }
+                });
+            }
+        })
+    };
+
+    let on_copy = {
+        let entries = entries.clone();
+        let copied_id = copied_id.clone();
+
+        Callback::from(move |entry_id: String| {
+            let entries = entries.clone();
+            let copied_id = copied_id.clone();
+            let entry_id_clone = entry_id.clone();
+
+            // Find and copy content to clipboard
+            if let Some(entry) = entries.iter().find(|e| e.id == entry_id) {
+                let content = entry.content.clone();
+                spawn_local(async move {
+                    // Copy to system clipboard using JS
+                    if let Some(window) = web_sys::window() {
+                        let navigator = window.navigator();
+                        let clipboard = navigator.clipboard();
+                        let _ = clipboard.write_text(&content);
+                    }
+
+                    // Update backend
+                    let args = EntryIdArgs {
+                        entry_id: entry_id_clone.clone(),
+                    };
+                    if let Ok(args_js) = serde_wasm_bindgen::to_value(&args) {
+                        if let Ok(_result) = invoke("copy_clipboard_entry_cmd", args_js).await {
+                            // Reload entries
+                            if let Ok(result) =
+                                invoke("load_clipboard_history_cmd", JsValue::null()).await
+                            {
+                                if let Ok(data) =
+                                    serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                                {
+                                    entries.set(data.entries);
+                                }
+                            }
+                        }
+                    }
+
+                    copied_id.set(Some(entry_id_clone));
+
+                    // Reset copied state after 2 seconds
+                    gloo_timers::callback::Timeout::new(2000, move || {
+                        copied_id.set(None);
+                    })
+                    .forget();
+                });
+            }
+        })
+    };
+
+    let on_toggle_pin = {
+        let entries = entries.clone();
+
+        Callback::from(move |entry_id: String| {
+            let entries = entries.clone();
+
+            spawn_local(async move {
+                let args = EntryIdArgs { entry_id };
+                if let Ok(args_js) = serde_wasm_bindgen::to_value(&args) {
+                    if let Ok(_result) = invoke("toggle_clipboard_pinned_cmd", args_js).await {
+                        // Reload entries
+                        if let Ok(result) =
+                            invoke("load_clipboard_history_cmd", JsValue::null()).await
+                        {
+                            if let Ok(data) =
+                                serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                            {
+                                entries.set(data.entries);
+                            }
+                        }
+                    }
+                }
+            });
+        })
+    };
+
+    let on_delete = {
+        let entries = entries.clone();
+        let settings = settings.clone();
+
+        Callback::from(move |entry_id: String| {
+            let entries = entries.clone();
+            let settings = settings.clone();
+
+            spawn_local(async move {
+                let args = EntryIdArgs { entry_id };
+                if let Ok(args_js) = serde_wasm_bindgen::to_value(&args) {
+                    if let Ok(result) = invoke("delete_clipboard_entry_cmd", args_js).await {
+                        if let Ok(data) =
+                            serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                        {
+                            entries.set(data.entries);
+                            settings.set(data.settings);
+                        }
+                    }
+                }
+            });
+        })
+    };
+
+    let on_clear_all = {
+        let entries = entries.clone();
+        let settings = settings.clone();
+
+        Callback::from(move |_| {
+            let entries = entries.clone();
+            let settings = settings.clone();
+
+            spawn_local(async move {
+                if let Ok(result) = invoke("clear_clipboard_history_cmd", JsValue::null()).await {
+                    if let Ok(data) =
+                        serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                    {
+                        entries.set(data.entries);
+                        settings.set(data.settings);
+                    }
+                }
+            });
+        })
+    };
+
+    let on_add_entry = {
+        let entries = entries.clone();
+        let new_entry_content = new_entry_content.clone();
+
+        Callback::from(move |_| {
+            let content = (*new_entry_content).clone();
+            if content.is_empty() {
+                return;
+            }
+
+            let entries = entries.clone();
+            let new_entry_content = new_entry_content.clone();
+
+            spawn_local(async move {
+                let args = AddEntryArgs { content };
+                if let Ok(args_js) = serde_wasm_bindgen::to_value(&args) {
+                    if let Ok(_result) = invoke("add_clipboard_entry_cmd", args_js).await {
+                        new_entry_content.set(String::new());
+                        // Reload entries
+                        if let Ok(result) =
+                            invoke("load_clipboard_history_cmd", JsValue::null()).await
+                        {
+                            if let Ok(data) =
+                                serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                            {
+                                entries.set(data.entries);
+                            }
+                        }
+                    }
+                }
+            });
+        })
+    };
+
+    let on_toggle_settings = {
+        let show_settings = show_settings.clone();
+        Callback::from(move |_| {
+            show_settings.set(!*show_settings);
+        })
+    };
+
+    let on_settings_change = {
+        let settings = settings.clone();
+        let entries = entries.clone();
+
+        Callback::from(move |new_settings: ClipboardSettings| {
+            let settings = settings.clone();
+            let entries = entries.clone();
+
+            spawn_local(async move {
+                let args = UpdateSettingsArgs {
+                    settings: new_settings,
+                };
+                if let Ok(args_js) = serde_wasm_bindgen::to_value(&args) {
+                    if let Ok(result) = invoke("update_clipboard_settings_cmd", args_js).await {
+                        if let Ok(data) =
+                            serde_wasm_bindgen::from_value::<ClipboardHistoryData>(result)
+                        {
+                            entries.set(data.entries);
+                            settings.set(data.settings);
+                        }
+                    }
+                }
+            });
+        })
+    };
+
+    let format_time = |created_at: &str| -> String {
+        // Parse RFC3339 date and show simplified format
+        if created_at.len() >= 10 {
+            // Extract date part (YYYY-MM-DD)
+            created_at[..10].to_string()
+        } else {
+            created_at.to_string()
+        }
+    };
+
+    let get_content_type_icon = |content_type: &ContentType| -> Html {
+        match content_type {
+            ContentType::Text => html! {
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6z"/>
+                    <path d="M14 2v6h6"/>
+                    <line x1="8" y1="13" x2="16" y2="13"/>
+                    <line x1="8" y1="17" x2="16" y2="17"/>
+                </svg>
+            },
+            ContentType::Code => html! {
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="16 18 22 12 16 6"/>
+                    <polyline points="8 6 2 12 8 18"/>
+                </svg>
+            },
+            ContentType::Url => html! {
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/>
+                    <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/>
+                </svg>
+            },
+            ContentType::Email => html! {
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
+                    <polyline points="22,6 12,13 2,6"/>
+                </svg>
+            },
+            ContentType::Password => html! {
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="11" width="18" height="11" rx="2"/>
+                    <path d="M7 11V7a5 5 0 0110 0v4"/>
+                </svg>
+            },
+        }
+    };
+
+    let truncate_content = |content: &str, max_len: usize| -> String {
+        if content.len() > max_len {
+            format!("{}...", &content[..max_len])
+        } else {
+            content.to_string()
+        }
+    };
+
+    // Separate pinned and regular entries
+    let pinned_entries: Vec<_> = entries.iter().filter(|e| e.pinned).cloned().collect();
+    let regular_entries: Vec<_> = entries.iter().filter(|e| !e.pinned).cloned().collect();
+
+    html! {
+        <div class="clipboard-history-container">
+            <div class="clipboard-history-header">
+                <h2 class="clipboard-history-title">{i18n.t("clipboard_history.title")}</h2>
+                <div class="clipboard-history-actions">
+                    <button
+                        class="clipboard-settings-btn"
+                        onclick={on_toggle_settings}
+                        title={i18n.t("clipboard_history.settings")}
+                    >
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="3"/>
+                            <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/>
+                        </svg>
+                    </button>
+                    <button
+                        class="clipboard-clear-btn"
+                        onclick={on_clear_all}
+                        title={i18n.t("common.clear_all")}
+                    >
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="3 6 5 6 21 6"/>
+                            <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            if *show_settings {
+                <div class="clipboard-settings-panel">
+                    <h3>{i18n.t("clipboard_history.settings")}</h3>
+                    <div class="settings-group">
+                        <label>{i18n.t("clipboard_history.max_entries")}</label>
+                        <input
+                            type="number"
+                            value={settings.max_entries.to_string()}
+                            min="10"
+                            max="1000"
+                            onchange={{
+                                let settings = settings.clone();
+                                let on_settings_change = on_settings_change.clone();
+                                Callback::from(move |e: Event| {
+                                    let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                    if let Ok(value) = input.value().parse::<u32>() {
+                                        let mut new_settings = (*settings).clone();
+                                        new_settings.max_entries = value.clamp(10, 1000);
+                                        on_settings_change.emit(new_settings);
+                                    }
+                                })
+                            }}
+                        />
+                    </div>
+                    <div class="settings-group">
+                        <label class="checkbox-label">
+                            <input
+                                type="checkbox"
+                                checked={settings.exclude_passwords}
+                                onchange={{
+                                    let settings = settings.clone();
+                                    let on_settings_change = on_settings_change.clone();
+                                    Callback::from(move |e: Event| {
+                                        let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                        let mut new_settings = (*settings).clone();
+                                        new_settings.exclude_passwords = input.checked();
+                                        on_settings_change.emit(new_settings);
+                                    })
+                                }}
+                            />
+                            {i18n.t("clipboard_history.exclude_passwords")}
+                        </label>
+                    </div>
+                </div>
+            }
+
+            <div class="clipboard-search-section">
+                <div class="search-input-wrapper">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8"/>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                    </svg>
+                    <input
+                        type="text"
+                        class="clipboard-search-input"
+                        placeholder={i18n.t("clipboard_history.search_placeholder")}
+                        value={(*search_query).clone()}
+                        oninput={on_search}
+                    />
+                </div>
+            </div>
+
+            <div class="clipboard-add-section">
+                <textarea
+                    class="clipboard-add-input"
+                    placeholder={i18n.t("clipboard_history.add_placeholder")}
+                    value={(*new_entry_content).clone()}
+                    oninput={{
+                        let new_entry_content = new_entry_content.clone();
+                        Callback::from(move |e: InputEvent| {
+                            let input: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+                            new_entry_content.set(input.value());
+                        })
+                    }}
+                />
+                <button
+                    class="clipboard-add-btn"
+                    onclick={on_add_entry}
+                    disabled={new_entry_content.is_empty()}
+                >
+                    {i18n.t("clipboard_history.add")}
+                </button>
+            </div>
+
+            <div class="clipboard-entries-list">
+                if *is_loading {
+                    <div class="clipboard-loading">{i18n.t("common.loading")}</div>
+                } else if entries.is_empty() {
+                    <div class="clipboard-empty">{i18n.t("clipboard_history.empty")}</div>
+                } else {
+                    if !pinned_entries.is_empty() {
+                        <div class="clipboard-section">
+                            <div class="clipboard-section-header">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                                </svg>
+                                {i18n.t("clipboard_history.pinned")}
+                            </div>
+                            { for pinned_entries.iter().map(|entry| {
+                                let entry_id_copy = entry.id.clone();
+                                let entry_id_pin = entry.id.clone();
+                                let entry_id_delete = entry.id.clone();
+                                let is_copied = *copied_id == Some(entry.id.clone());
+                                let on_copy = on_copy.clone();
+                                let on_toggle_pin = on_toggle_pin.clone();
+                                let on_delete = on_delete.clone();
+
+                                let is_code = entry.content_type == ContentType::Code;
+                                html! {
+                                    <div class={classes!("clipboard-entry", "pinned", is_code.then_some("code-entry"))}>
+                                        <div class="entry-content-wrapper">
+                                            <span class="entry-type-icon">
+                                                {get_content_type_icon(&entry.content_type)}
+                                            </span>
+                                            <div class="entry-content">
+                                                <pre class="entry-text">{truncate_content(&entry.content, 200)}</pre>
+                                                <div class="entry-meta">
+                                                    <span class="entry-time">{format_time(&entry.created_at)}</span>
+                                                    <span class="entry-count">{format!("{} {}", entry.copied_count, i18n.t("clipboard_history.copies"))}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="entry-actions">
+                                            <button
+                                                class={classes!("entry-btn", "copy-btn", is_copied.then_some("copied"))}
+                                                onclick={Callback::from(move |_| on_copy.emit(entry_id_copy.clone()))}
+                                                title={i18n.t("common.copy")}
+                                            >
+                                                if is_copied {
+                                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                        <polyline points="20 6 9 17 4 12"/>
+                                                    </svg>
+                                                } else {
+                                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                        <rect x="9" y="9" width="13" height="13" rx="2"/>
+                                                        <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                                                    </svg>
+                                                }
+                                            </button>
+                                            <button
+                                                class={classes!("entry-btn", "pin-btn", "active")}
+                                                onclick={Callback::from(move |_| on_toggle_pin.emit(entry_id_pin.clone()))}
+                                                title={i18n.t("clipboard_history.unpin")}
+                                            >
+                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                                                </svg>
+                                            </button>
+                                            <button
+                                                class="entry-btn delete-btn"
+                                                onclick={Callback::from(move |_| on_delete.emit(entry_id_delete.clone()))}
+                                                title={i18n.t("common.delete")}
+                                            >
+                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <line x1="18" y1="6" x2="6" y2="18"/>
+                                                    <line x1="6" y1="6" x2="18" y2="18"/>
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                }
+                            })}
+                        </div>
+                    }
+
+                    if !regular_entries.is_empty() {
+                        <div class="clipboard-section">
+                            <div class="clipboard-section-header">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <circle cx="12" cy="12" r="10"/>
+                                    <polyline points="12 6 12 12 16 14"/>
+                                </svg>
+                                {i18n.t("clipboard_history.recent")}
+                            </div>
+                            { for regular_entries.iter().map(|entry| {
+                                let entry_id_copy = entry.id.clone();
+                                let entry_id_pin = entry.id.clone();
+                                let entry_id_delete = entry.id.clone();
+                                let is_copied = *copied_id == Some(entry.id.clone());
+                                let is_code = entry.content_type == ContentType::Code;
+                                let on_copy = on_copy.clone();
+                                let on_toggle_pin = on_toggle_pin.clone();
+                                let on_delete = on_delete.clone();
+
+                                html! {
+                                    <div class={classes!("clipboard-entry", is_code.then_some("code-entry"))}>
+                                        <div class="entry-content-wrapper">
+                                            <span class="entry-type-icon">
+                                                {get_content_type_icon(&entry.content_type)}
+                                            </span>
+                                            <div class="entry-content">
+                                                <pre class="entry-text">{truncate_content(&entry.content, 200)}</pre>
+                                                <div class="entry-meta">
+                                                    <span class="entry-time">{format_time(&entry.created_at)}</span>
+                                                    <span class="entry-count">{format!("{} {}", entry.copied_count, i18n.t("clipboard_history.copies"))}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="entry-actions">
+                                            <button
+                                                class={classes!("entry-btn", "copy-btn", is_copied.then_some("copied"))}
+                                                onclick={Callback::from(move |_| on_copy.emit(entry_id_copy.clone()))}
+                                                title={i18n.t("common.copy")}
+                                            >
+                                                if is_copied {
+                                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                        <polyline points="20 6 9 17 4 12"/>
+                                                    </svg>
+                                                } else {
+                                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                        <rect x="9" y="9" width="13" height="13" rx="2"/>
+                                                        <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                                                    </svg>
+                                                }
+                                            </button>
+                                            <button
+                                                class="entry-btn pin-btn"
+                                                onclick={Callback::from(move |_| on_toggle_pin.emit(entry_id_pin.clone()))}
+                                                title={i18n.t("clipboard_history.pin")}
+                                            >
+                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                                                </svg>
+                                            </button>
+                                            <button
+                                                class="entry-btn delete-btn"
+                                                onclick={Callback::from(move |_| on_delete.emit(entry_id_delete.clone()))}
+                                                title={i18n.t("common.delete")}
+                                            >
+                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <line x1="18" y1="6" x2="6" y2="18"/>
+                                                    <line x1="6" y1="6" x2="18" y2="18"/>
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </div>
+                                }
+                            })}
+                        </div>
+                    }
+                }
+            </div>
+
+            <div class="clipboard-footer">
+                <span class="entries-count">
+                    {format!("{} {}", entries.len(), i18n.t("clipboard_history.entries"))}
+                </span>
+            </div>
+        </div>
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod base64_encoder;
+pub mod clipboard_history;
 pub mod csv_viewer;
 pub mod image_compressor;
 pub mod image_editor;

--- a/src/components/unix_time_converter.rs
+++ b/src/components/unix_time_converter.rs
@@ -103,7 +103,8 @@ pub fn unix_time_converter() -> Html {
                 move || {
                     let current_time = current_time.clone();
                     spawn_local(async move {
-                        if let Ok(result) = invoke("get_current_unix_time_cmd", JsValue::NULL).await {
+                        if let Ok(result) = invoke("get_current_unix_time_cmd", JsValue::NULL).await
+                        {
                             if let Ok(res) =
                                 serde_wasm_bindgen::from_value::<CurrentUnixTimeResult>(result)
                             {
@@ -122,7 +123,8 @@ pub fn unix_time_converter() -> Html {
                 let current_time = current_time.clone();
                 spawn_local(async move {
                     if let Ok(result) = invoke("get_current_unix_time_cmd", JsValue::NULL).await {
-                        if let Ok(res) = serde_wasm_bindgen::from_value::<CurrentUnixTimeResult>(result)
+                        if let Ok(res) =
+                            serde_wasm_bindgen::from_value::<CurrentUnixTimeResult>(result)
                         {
                             current_time.set(Some(res));
                         }
@@ -228,7 +230,9 @@ pub fn unix_time_converter() -> Html {
 
                             match invoke("unix_to_datetime_cmd", args).await {
                                 Ok(result) => {
-                                    match serde_wasm_bindgen::from_value::<UnixToDatetimeResult>(result) {
+                                    match serde_wasm_bindgen::from_value::<UnixToDatetimeResult>(
+                                        result,
+                                    ) {
                                         Ok(res) => {
                                             if res.success {
                                                 datetime_result.set(Some(res));
@@ -243,7 +247,8 @@ pub fn unix_time_converter() -> Html {
                                     }
                                 }
                                 Err(e) => {
-                                    let err_msg = e.as_string().unwrap_or_else(|| format!("{:?}", e));
+                                    let err_msg =
+                                        e.as_string().unwrap_or_else(|| format!("{:?}", e));
                                     error.set(Some(format!("Invoke error: {}", err_msg)));
                                 }
                             }
@@ -260,7 +265,8 @@ pub fn unix_time_converter() -> Html {
 
                         match invoke("datetime_to_unix_cmd", args).await {
                             Ok(result) => {
-                                match serde_wasm_bindgen::from_value::<DatetimeToUnixResult>(result) {
+                                match serde_wasm_bindgen::from_value::<DatetimeToUnixResult>(result)
+                                {
                                     Ok(res) => {
                                         if res.success {
                                             unix_result.set(Some(res));

--- a/src/i18n/translations.rs
+++ b/src/i18n/translations.rs
@@ -63,7 +63,8 @@ pub const EN_TRANSLATIONS: &str = r#"{
       "regex": "Regex",
       "json": "JSON",
       "base64": "Base64",
-      "unix_time": "Unix Time"
+      "unix_time": "Unix Time",
+      "clipboard": "Clipboard"
     }
   },
   "language_switcher": {
@@ -298,6 +299,26 @@ pub const EN_TRANSLATIONS: &str = r#"{
     "click_to_change": "Click to change image",
     "original_size": "Original:"
   },
+  "clipboard_history": {
+    "title": "Clipboard History",
+    "settings": "Settings",
+    "max_entries": "Max Entries",
+    "exclude_passwords": "Exclude Passwords",
+    "search_placeholder": "Search clipboard history...",
+    "add_placeholder": "Add new entry...",
+    "add": "Add",
+    "empty": "No clipboard history yet",
+    "pinned": "Pinned",
+    "recent": "Recent",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "copies": "copies",
+    "entries": "entries",
+    "just_now": "Just now",
+    "minutes_ago": "minutes ago",
+    "hours_ago": "hours ago",
+    "days_ago": "days ago"
+  },
   "unix_time_converter": {
     "title": "Unix Time Converter",
     "current_time": "Current Time",
@@ -391,7 +412,8 @@ pub const JA_TRANSLATIONS: &str = r#"{
       "regex": "正規表現",
       "json": "JSON",
       "base64": "Base64",
-      "unix_time": "Unix時間"
+      "unix_time": "Unix時間",
+      "clipboard": "クリップボード"
     }
   },
   "language_switcher": {
@@ -625,6 +647,26 @@ pub const JA_TRANSLATIONS: &str = r#"{
     "copy_data_url": "Data URLをコピー",
     "click_to_change": "クリックで画像を変更",
     "original_size": "元サイズ:"
+  },
+  "clipboard_history": {
+    "title": "クリップボード履歴",
+    "settings": "設定",
+    "max_entries": "最大保存件数",
+    "exclude_passwords": "パスワードを除外",
+    "search_placeholder": "履歴を検索...",
+    "add_placeholder": "新しいエントリを追加...",
+    "add": "追加",
+    "empty": "履歴がありません",
+    "pinned": "ピン留め",
+    "recent": "最近",
+    "pin": "ピン留め",
+    "unpin": "ピン解除",
+    "copies": "回コピー",
+    "entries": "件",
+    "just_now": "たった今",
+    "minutes_ago": "分前",
+    "hours_ago": "時間前",
+    "days_ago": "日前"
   },
   "unix_time_converter": {
     "title": "Unix時間変換",

--- a/styles.css
+++ b/styles.css
@@ -5327,3 +5327,367 @@ body {
 .unix-time-converter .result-value-row .result-value {
   flex: 1;
 }
+
+/* ===== Clipboard History Component ===== */
+.clipboard-history-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  background: var(--bg-base);
+}
+
+.clipboard-history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.clipboard-history-title {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.clipboard-history-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.clipboard-settings-btn,
+.clipboard-clear-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.clipboard-settings-btn:hover,
+.clipboard-clear-btn:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.clipboard-clear-btn:hover {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.clipboard-settings-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+}
+
+.clipboard-settings-panel h3 {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 var(--space-3) 0;
+}
+
+.settings-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.settings-group:last-child {
+  margin-bottom: 0;
+}
+
+.settings-group label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.settings-group input[type="number"] {
+  width: 100px;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.settings-group input[type="number"]:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-primary);
+}
+
+.clipboard-search-section {
+  position: relative;
+}
+
+.search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-input-wrapper svg {
+  position: absolute;
+  left: var(--space-3);
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.clipboard-search-input {
+  width: 100%;
+  padding: var(--space-3) var(--space-3) var(--space-3) 40px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.clipboard-search-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  background: var(--bg-elevated);
+}
+
+.clipboard-search-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.clipboard-add-section {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.clipboard-add-input {
+  flex: 1;
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  resize: none;
+  min-height: 60px;
+  max-height: 120px;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.clipboard-add-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.clipboard-add-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.clipboard-add-btn {
+  padding: var(--space-3) var(--space-4);
+  background: var(--accent-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--bg-base);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  align-self: flex-end;
+}
+
+.clipboard-add-btn:hover:not(:disabled) {
+  background: var(--accent-primary-glow);
+  box-shadow: var(--shadow-glow);
+}
+
+.clipboard-add-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.clipboard-entries-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.clipboard-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.clipboard-section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: var(--space-2) 0;
+}
+
+.clipboard-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.clipboard-entry:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-strong);
+}
+
+.clipboard-entry.pinned {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-dim);
+}
+
+.clipboard-entry.code-entry {
+  background: var(--bg-elevated);
+}
+
+.entry-content-wrapper {
+  flex: 1;
+  display: flex;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.entry-type-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+}
+
+.entry-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.entry-text {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.5;
+  max-height: 80px;
+  overflow: hidden;
+}
+
+.entry-meta {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.entry-actions {
+  display: flex;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.entry-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.entry-btn:hover {
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+}
+
+.entry-btn.copy-btn:hover {
+  color: var(--accent-primary);
+}
+
+.entry-btn.copy-btn.copied {
+  color: var(--success);
+}
+
+.entry-btn.pin-btn:hover {
+  color: var(--warning);
+}
+
+.entry-btn.pin-btn.active {
+  color: var(--warning);
+}
+
+.entry-btn.delete-btn:hover {
+  color: var(--error);
+}
+
+.clipboard-loading,
+.clipboard-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8);
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.clipboard-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.entries-count {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}


### PR DESCRIPTION
## Summary
- クリップボード履歴の自動監視・保存機能を追加（バックエンドで1秒間隔のポーリング）
- ピン留め、検索、手動追加、削除、全クリア機能を実装
- コンテンツタイプ自動検出（テキスト、コード、URL、メール、パスワード）
- 設定（最大保存件数、パスワード除外）のカスタマイズに対応
- 日本語・英語の翻訳を追加

## 動作確認
- [ ] クリップボード履歴の表示
- [ ] エントリのコピー・ピン留め・削除
- [ ] 検索機能
- [ ] 設定変更
- [ ] クリップボード自動監視

## 確認事項
- [x] `arboard` crateを依存関係に追加
- [x] フロントエンド・バックエンド間のcamelCase変換対応
- [x] i18n翻訳（EN/JA）追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)